### PR TITLE
switching to squared modal header; release 0.1.1-a2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.1.0",
+  "version": "0.1.1-a2",
   "description": "",
   "main": "./lib/form.js",
   "types": "./lib/form.d.ts",
@@ -13,6 +13,7 @@
     "build": "yarn release",
     "serve": "http-server dist/ -s",
     "compile": "tsc -d --project tsconfig-compile.json --outDir lib/",
+    "prepare": "yarn compile",
     "upload": "rsync -avr --progress dist/ fe.jimu.io:~/repo/jimengio/meson-form",
     "postinstall": "rm -rfv node_modules/@types/*/node_modules/@types/react"
   },

--- a/src/component/modal.tsx
+++ b/src/component/modal.tsx
@@ -111,7 +111,6 @@ let stylePopPage = css`
   background-color: white;
   min-width: 520px;
   min-height: 160px;
-  border-radius: 4px;
 
   transform-origin: 50% -50%;
 
@@ -133,7 +132,9 @@ let styleBackdrop = css`
 `;
 
 let styleHeader = css`
-  padding: 12px;
+  padding: 0 24px;
+  height: 56px;
+  font-size: 16px;
   font-weight: bold;
   border-bottom: 1px solid hsl(0, 0%, 91%);
 `;
@@ -141,4 +142,5 @@ let styleHeader = css`
 let styleIcon = css`
   color: #aaa;
   cursor: pointer;
+  font-size: 12px;
 `;


### PR DESCRIPTION
Using a squared header to fix new design.

![image](https://user-images.githubusercontent.com/449224/56490905-5a97db00-6519-11e9-8a9a-575ff4c75ed0.png)
