### PR TITLE
Support fragment type

### DIFF
--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -88,6 +88,19 @@ export default (props) => {
       required: true,
     },
     {
+      type: EMesonFieldType.Fragment,
+      shouldHide: () => true,
+      children: [
+        {
+          type: EMesonFieldType.Input,
+          textarea: true,
+          label: "描述",
+          name: "description",
+          required: true,
+        },
+      ],
+    },
+    {
       type: EMesonFieldType.Group,
       label: "group",
       children: [{ type: EMesonFieldType.Select, label: "物料", name: "materialInside", required: true, options: options }],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.1.3",
+  "version": "0.1.4-a1",
   "description": "",
   "main": "./lib/form.js",
   "types": "./lib/form.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.1.4-a1",
+  "version": "0.1.4-a2",
   "description": "",
   "main": "./lib/form.js",
   "types": "./lib/form.d.ts",

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -126,7 +126,7 @@ export let MesonForm: SFC<{
         let onChange = (value: any) => {
           updateItem(value, item);
         };
-        return item.render(form[item.name], onChange);
+        return item.render(form[item.name], onChange, form);
     }
     return <div>Unknown type: {(item as any).type}</div>;
   };

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -1,4 +1,4 @@
-import React, { SFC, ReactNode, CSSProperties } from "react";
+import React, { SFC, ReactNode, CSSProperties, useState } from "react";
 import { row, column, flex } from "@jimengio/shared-utils";
 import { css, cx } from "emotion";
 import { Input, InputNumber, Select, Button } from "antd";
@@ -23,9 +23,11 @@ export let MesonForm: SFC<{
   footerLayout?: EMesonFooterLayout;
   renderFooter?: (isLoading: boolean, onSubmit: () => void, onCancel: () => void) => ReactNode;
   isLoading?: boolean;
+  onFieldChange?: (name: string, v: any) => void;
 }> = (props) => {
   let [form, updateForm] = useImmer(props.initialValue);
   let [errors, updateErrors] = useImmer({});
+  let [modified, setModified] = useState<boolean>(false);
 
   let checkItem = (item: IMesonFieldItemHasValue) => {
     let result = validateItem(form[item.name], item);
@@ -47,6 +49,9 @@ export let MesonForm: SFC<{
     });
     if (item.onChange != null) {
       item.onChange(x);
+    }
+    if (props.onFieldChange != null) {
+      props.onFieldChange(item.name, x);
     }
   };
 
@@ -185,6 +190,7 @@ export let MesonForm: SFC<{
           return serverErrors;
         });
       });
+      setModified(false);
     }
   };
 

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -137,6 +137,10 @@ export let MesonForm: SFC<{
         return null;
       }
 
+      if (item.type === EMesonFieldType.Fragment) {
+        return <>{renderItems(item.children)}</>;
+      }
+
       let name: string = (item as any).name;
       let error = name != null ? errors[name] : null;
 

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -65,7 +65,7 @@ export interface IMesonSelectField<K> extends IMesonFieldBaseProps {
 export interface IMesonCustomField<K> extends IMesonFieldBaseProps {
   name: K;
   type: EMesonFieldType.Custom;
-  render: (value: any, onChange: (x: any) => void) => ReactNode;
+  render: (value: any, onChange: (x: any) => void, form: any) => ReactNode;
   onChange?: (x: any) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator)[];
   validator?: FuncMesonValidator;

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -18,6 +18,8 @@ export enum EMesonFieldType {
   Select = "select",
   Custom = "custom",
   Group = "group",
+  // like React fragment
+  Fragment = "fragment",
 }
 
 export interface IMesonFieldBaseProps<K = string> {
@@ -76,5 +78,17 @@ export interface IMesonGroupField extends IMesonFieldBaseProps {
   children: IMesonFieldItem[];
 }
 
+export interface IMesonFieldsFragment {
+  type: EMesonFieldType.Fragment;
+  shouldHide?: (form: any) => boolean;
+  children: IMesonFieldItem[];
+}
+
 export type IMesonFieldItemHasValue<K = string> = IMesonInputField<K> | IMesonNumberField<K> | IMesonSelectField<K> | IMesonCustomField<K>;
-export type IMesonFieldItem<K = string> = IMesonInputField<K> | IMesonNumberField<K> | IMesonSelectField<K> | IMesonCustomField<K> | IMesonGroupField;
+export type IMesonFieldItem<K = string> =
+  | IMesonInputField<K>
+  | IMesonNumberField<K>
+  | IMesonSelectField<K>
+  | IMesonCustomField<K>
+  | IMesonGroupField
+  | IMesonFieldsFragment;


### PR DESCRIPTION
* New type. Fragment is like group, but it has no label. It's children are rendered in the same level of current form.
* Pass current `form` to render function in type `Custom`.
