### PR TITLE
layout changes; use a special container for Custom value renderer

### DIFF
--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -7,7 +7,7 @@ import { EMesonValidate, IMesonSelectItem, IMesonFieldItem, EMesonFieldType } fr
 import MesonModal from "../../src/component/modal";
 import { lingual } from "../../src/lingual";
 import { EMesonFooterLayout } from "../../src/component/form-footer";
-import { column } from "@jimengio/shared-utils";
+import { column, row } from "@jimengio/shared-utils";
 
 interface IDemo {
   material: string;
@@ -101,6 +101,14 @@ export default (props) => {
       ],
     },
     {
+      type: EMesonFieldType.Custom,
+      name: null,
+      label: "Width test",
+      render: (value) => {
+        return <div className={styleWideColor} />;
+      },
+    },
+    {
       type: EMesonFieldType.Group,
       label: "group",
       children: [{ type: EMesonFieldType.Select, label: "物料", name: "materialInside", required: true, options: options }],
@@ -111,13 +119,17 @@ export default (props) => {
       label: "自定义",
       render: (value, onChange) => {
         return (
-          <Input
-            value={value}
-            onChange={(event) => {
-              let newValue = event.target.value;
-              onChange(newValue);
-            }}
-          />
+          <div className={row}>
+            <div>
+              <Input
+                value={value}
+                onChange={(event) => {
+                  let newValue = event.target.value;
+                  onChange(newValue);
+                }}
+              />
+            </div>
+          </div>
         );
       },
     },
@@ -125,8 +137,6 @@ export default (props) => {
 
   return (
     <div className={styleContainer}>
-      <div className={styleTitle}>Form example</div>
-
       <div className={styleBoxArea}>
         <div>
           <Button
@@ -135,32 +145,7 @@ export default (props) => {
             }}
           >
             Try Modal
-          </Button>
-        </div>
-        <MesonModal
-          title={lingual.labelShouldBeString}
-          visible={visible}
-          onClose={() => {
-            setVisible(false);
-          }}
-          renderContent={() => {
-            return (
-              <div>
-                SOMETHING
-                <span
-                  onClick={() => {
-                    setVisible(false);
-                  }}
-                >
-                  Close
-                </span>
-              </div>
-            );
-          }}
-        />
-      </div>
-      <div className={styleBoxArea}>
-        <div>
+          </Button>{" "}
           <Button
             onClick={() => {
               setFormVisible(true);
@@ -169,19 +154,6 @@ export default (props) => {
             Open Form Modal
           </Button>
         </div>
-        <MesonFormModal
-          title={lingual.labelShouldBeBoolean}
-          visible={formVisible}
-          onClose={() => {
-            setFormVisible(false);
-          }}
-          items={formItems}
-          initialValue={{}}
-          onSubmit={(form) => {
-            console.log("form", form);
-            setFormVisible(false);
-          }}
-        />
       </div>
 
       <div className={cx(column, styleFormArea)}>
@@ -197,16 +169,48 @@ export default (props) => {
           footerLayout={EMesonFooterLayout.Center}
         />
       </div>
+
+      <MesonModal
+        title={lingual.labelShouldBeString}
+        visible={visible}
+        onClose={() => {
+          setVisible(false);
+        }}
+        renderContent={() => {
+          return (
+            <div>
+              SOMETHING
+              <span
+                onClick={() => {
+                  setVisible(false);
+                }}
+              >
+                Close
+              </span>
+            </div>
+          );
+        }}
+      />
+      <MesonFormModal
+        title={lingual.labelShouldBeBoolean}
+        visible={formVisible}
+        onClose={() => {
+          setFormVisible(false);
+        }}
+        items={formItems}
+        initialValue={{}}
+        onSubmit={(form) => {
+          console.log("form", form);
+          setFormVisible(false);
+        }}
+      />
     </div>
   );
 };
 
 const styleContainer = css`
   font-family: "Helvetica";
-`;
-
-const styleTitle = css`
-  margin-bottom: 16px;
+  padding: 16px;
 `;
 
 let styleBoxArea = css`
@@ -217,4 +221,11 @@ let styleFormArea = css`
   width: 480px;
   height: 660px;
   border: 1px solid #ccc;
+`;
+
+let styleWideColor = css`
+  background-color: #eee;
+  height: 40px;
+  width: 600px;
+  max-width: 100%;
 `;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.1.4",
+  "version": "0.1.5-a2",
   "description": "",
   "main": "./lib/form.js",
   "types": "./lib/form.d.ts",

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -8,7 +8,6 @@ import { IMesonFieldItem, EMesonFieldType, IMesonFieldItemHasValue, ISimpleObjec
 import { validateValueRequired, validateByMethods, validateItem } from "./util/validation";
 import { traverseItems } from "./util/render";
 import { RequiredMark } from "./component/misc";
-import is from "is";
 import { FormFooter, EMesonFooterLayout } from "./component/form-footer";
 import MesonModal from "./component/modal";
 import TextArea from "antd/lib/input/TextArea";
@@ -128,10 +127,7 @@ export let MesonForm: SFC<{
       case EMesonFieldType.Group:
         return renderItems(item.children);
       case EMesonFieldType.Custom:
-        let onChange = (value: any) => {
-          updateItem(value, item);
-        };
-        return item.render(form[item.name], onChange, form);
+      // already handled outside
     }
     return <div>Unknown type: {(item as any).type}</div>;
   };
@@ -149,15 +145,37 @@ export let MesonForm: SFC<{
       let name: string = (item as any).name;
       let error = name != null ? errors[name] : null;
 
+      let labelNode = (
+        <div className={styleLabel}>
+          {item.required ? <RequiredMark /> : null}
+          {item.label}:
+        </div>
+      );
+
+      let errorNode = error != null ? <div className={styleError}>{error}</div> : null;
+
+      if (item.type === EMesonFieldType.Custom) {
+        let onChange = (value: any) => {
+          updateItem(value, item);
+        };
+
+        return (
+          <div key={idx} className={cx(row, styleItemRow)}>
+            {labelNode}
+            <div className={cx(flex, column, styleValueArea)}>
+              {item.render(form[item.name], onChange, form)}
+              {errorNode}
+            </div>
+          </div>
+        );
+      }
+
       return (
         <div key={idx} className={cx(row, styleItemRow)}>
-          <div className={styleLabel}>
-            {item.required ? <RequiredMark /> : null}
-            {item.label}:
-          </div>
-          <div className={cx(column, styleValueArea)}>
+          {labelNode}
+          <div className={cx(styleValueArea)}>
             {renderValueItem(item)}
-            {error != null ? <div className={styleError}>{error}</div> : null}
+            {errorNode}
           </div>
         </div>
       );
@@ -251,16 +269,19 @@ let styleLabel = css`
   margin-right: 8px;
 `;
 
-let styleValueArea = css``;
+let styleValueArea = css`
+  overflow: auto;
+`;
 
 let styleItemRow = css`
   line-height: 32px;
-  margin-bottom: 24px;
+  margin-bottom: 16px;
   font-size: 14px;
 `;
 
 let styleControlBase = css`
   min-width: 180px;
+  width: 180px;
 `;
 
 let styleError = css`
@@ -269,9 +290,10 @@ let styleError = css`
 
 let styleItemsContainer = css`
   overflow: auto;
-  padding-top: 24px;
+  padding: 24px 16px 24px;
 `;
 
 let styleTextareaBase = css`
+  width: 240px;
   min-width: 240px;
 `;

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -67,6 +67,9 @@ export interface IMesonSelectField<K> extends IMesonFieldBaseProps {
 export interface IMesonCustomField<K> extends IMesonFieldBaseProps {
   name: K;
   type: EMesonFieldType.Custom;
+  /** parent container is using column,
+   * for antd inputs with default with 100%, you need to take care of that by yourself
+   */
   render: (value: any, onChange: (x: any) => void, form: any) => ReactNode;
   onChange?: (x: any) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator)[];


### PR DESCRIPTION
表单容易宽度缩小时, Custom renderer 当中渲染的内容也要跟着变小, 所以用了 Flexbox 加上  `overflow:hidden`.

由于 antd input 默认有 `width:100%`, 还得用普通的 inline block 进行重置... 导致结构挺复杂的...