### PR TITLE
added hooks version of meson form; alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ export let MesonForm: SFC<{
 };
 ```
 
+### Low level Hooks API
+
+`useMesonCore` is a low level API for maintaining form states. The UI part need extra code.
+
+```ts
+let { formAny, errors, onCheckSubmit, checkItem, updateItem, forcelyResetForm } = useMesonCore({
+  initialValue: submittedForm,
+  items: formItems,
+  onSubmit: onSubmit,
+});
+```
+
 ### Workflow
 
 https://github.com/jimengio/ts-workflow

--- a/example/controller/generated-router.ts
+++ b/example/controller/generated-router.ts
@@ -61,6 +61,12 @@ export let genRouter = {
     path: () => `/custom`,
     go: () => switchPath(`/custom`),
   },
+  wrapMesonCore: {
+    name: "wrap-meson-core",
+    raw: "wrap-meson-core",
+    path: () => `/wrap-meson-core`,
+    go: () => switchPath(`/wrap-meson-core`),
+  },
   _: {
     name: "home",
     raw: "",

--- a/example/forms/wrap-meson-core.tsx
+++ b/example/forms/wrap-meson-core.tsx
@@ -1,0 +1,107 @@
+import React, { FC, useState } from "react";
+import { css } from "emotion";
+import { useMesonCore } from "../../src/hook/meson-core";
+import { IMesonCustomField, EMesonFieldType, IMesonFieldItem, EMesonValidate } from "../../src/model/types";
+import { column } from "@jimengio/shared-utils";
+
+interface ILoginForm {
+  username: string;
+  password: string;
+}
+
+let formItems: IMesonFieldItem[] = [
+  {
+    type: EMesonFieldType.Input,
+    name: "username",
+    label: null,
+    placeholder: "Username",
+    required: true,
+  },
+  {
+    type: EMesonFieldType.Input,
+    name: "password",
+    inputType: "password",
+    placeholder: "Password",
+    label: null,
+    required: true,
+  },
+];
+
+let WrapMesonCore: FC<{}> = (props) => {
+  let [submittedForm, setSubmittedForm] = useState({} as any);
+  let [turn, setTurn] = useState(0);
+
+  let onSubmit = (form: ILoginForm) => {
+    setSubmittedForm(form);
+  };
+
+  let { formAny, errors, onCheckSubmit, checkItem, updateItem, forcelyResetForm } = useMesonCore({
+    initialValue: submittedForm,
+    items: formItems,
+    onSubmit: onSubmit,
+  });
+
+  let form = formAny as ILoginForm;
+
+  return (
+    <div className={styleContainer}>
+      <div>
+        This page demonstrates a form using hooks and renders by user.{" "}
+        <a href="https://github.com/jimengio/meson-form/tree/master/example/forms/wrap-form-core.tsx">Source code</a>
+      </div>
+      <div>
+        Data:
+        <code>{JSON.stringify(submittedForm)}</code>
+        <button
+          onClick={() => {
+            setSubmittedForm({});
+            forcelyResetForm({});
+          }}
+        >
+          Reset
+        </button>
+      </div>
+
+      <div className={styleFormArea}>
+        {formItems.map((item) => {
+          switch (item.type) {
+            case EMesonFieldType.Input:
+              return (
+                <div className={column} key={item.name}>
+                  <input
+                    value={form[item.name] || ""}
+                    type={item.inputType}
+                    placeholder={item.placeholder}
+                    onChange={(event) => {
+                      let text = event.target.value;
+                      updateItem(text, item);
+                    }}
+                    onBlur={() => {
+                      checkItem(item);
+                    }}
+                  />
+                  {errors[item.name] != null ? <div className={styleError}>{errors[item.name]}</div> : null}
+                </div>
+              );
+          }
+        })}
+        <div>
+          <button onClick={onCheckSubmit}>Submit</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WrapMesonCore;
+
+let styleContainer = css``;
+
+let styleError = css`
+  color: red;
+`;
+
+let styleFormArea = css`
+  width: 200px;
+  padding: 16px;
+`;

--- a/example/models/router-rules.ts
+++ b/example/models/router-rules.ts
@@ -11,5 +11,6 @@ export const routerRules: IRouteRule[] = [
   { path: "select" },
   { path: "validation" },
   { path: "custom" },
+  { path: "wrap-meson-core" },
   { path: "", name: "home" },
 ];

--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -11,6 +11,7 @@ import SelectPage from "forms/select-page";
 import ValidationPage from "forms/validation";
 import CustomPage from "forms/custom";
 import AutoSavePage from "forms/auto-save";
+import WrapMesonCore from "forms/wrap-meson-core";
 
 let pages: { title: string; path: string }[] = [
   {
@@ -45,6 +46,10 @@ let pages: { title: string; path: string }[] = [
     title: "Auto save",
     path: genRouter.autoSave.name,
   },
+  {
+    title: "Use meson core",
+    path: genRouter.wrapMesonCore.name,
+  },
 ];
 
 let Container: SFC<{ router: IRouteParseResult }> = (props) => {
@@ -64,6 +69,8 @@ let Container: SFC<{ router: IRouteParseResult }> = (props) => {
         return <CustomPage />;
       case genRouter.autoSave.name:
         return <AutoSavePage />;
+      case genRouter.wrapMesonCore.name:
+        return <WrapMesonCore />;
       default:
         return <FormBasic />;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.1.11",
+  "version": "0.1.12-a1",
   "description": "",
   "main": "./lib/form.js",
   "types": "./lib/form.d.ts",
@@ -15,7 +15,7 @@
     "compile": "tsc -d --project tsconfig-compile.json --outDir lib/",
     "prepare": "yarn compile",
     "upload": "rsync -avr --progress dist/ fe.jimu.io:~/repo/jimengio/meson-form",
-    "prepublishOnly": "yarn release & yarn upload",
+    "up": "yarn release && yarn upload",
     "gen-router": "webpack --config webpack/router-config.js && node dist/gen-router.js",
     "postinstall": "rm -rfv node_modules/@types/*/node_modules/@types/react"
   },

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -127,6 +127,7 @@ export let MesonForm: SFC<{
         return (
           <Input
             value={form[item.name]}
+            type={item.inputType || "text"}
             placeholder={item.placeholder || formatString(lingual.pleaseInputLabel, { label: item.label })}
             className={styleControlBase}
             onChange={(event) => {

--- a/src/hook/meson-core.ts
+++ b/src/hook/meson-core.ts
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { useImmer } from "use-immer";
+import { IMesonFieldItem, EMesonFieldType, IMesonFieldItemHasValue, ISimpleObject } from "../model/types";
+import { validateValueRequired, validateByMethods, validateItem } from "../util/validation";
+import { traverseItems } from "../util/render";
+import produce from "immer";
+
+/** low level hook for creating forms with very specific UIs */
+export let useMesonCore = (props: {
+  initialValue: any;
+  items: IMesonFieldItem[];
+  onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: ISimpleObject) => void) => void;
+  onFieldChange?: (name: string, v: any, prevForm?: { [k: string]: any }) => void;
+  submitOnEdit?: boolean;
+}) => {
+  let [form, updateForm] = useImmer(props.initialValue);
+  let [errors, updateErrors] = useImmer({});
+  let [modified, setModified] = useState<boolean>(false);
+
+  let onCheckSubmitWithValue = (specifiedForm?: { [k: string]: any }) => {
+    let latestForm = specifiedForm;
+    let currentErrors: ISimpleObject = {};
+    let hasErrors = false;
+    traverseItems(props.items, (item: IMesonFieldItemHasValue) => {
+      if (item.shouldHide != null && item.shouldHide(latestForm)) {
+        return null;
+      }
+
+      let result = validateItem(latestForm[item.name], item);
+
+      if (result != null) {
+        currentErrors[item.name] = result;
+        hasErrors = true;
+      }
+    });
+
+    updateErrors((draft: ISimpleObject) => {
+      return currentErrors;
+    });
+
+    if (!hasErrors) {
+      props.onSubmit(latestForm, (serverErrors) => {
+        updateErrors((draft: ISimpleObject) => {
+          return serverErrors;
+        });
+      });
+      setModified(false);
+    }
+  };
+
+  let onCheckSubmit = () => {
+    onCheckSubmitWithValue(form);
+  };
+
+  let checkItem = (item: IMesonFieldItemHasValue) => {
+    if (props.submitOnEdit) {
+      onCheckSubmitWithValue(form);
+      return;
+    }
+
+    let result = validateItem(form[item.name], item);
+    updateErrors((draft) => {
+      draft[item.name] = result;
+    });
+  };
+
+  let checkItemWithValue = (x: any, item: IMesonFieldItemHasValue) => {
+    if (props.submitOnEdit) {
+      let newForm = produce(form, (draft) => {
+        draft[item.name] = x;
+      });
+      onCheckSubmitWithValue(newForm);
+      return;
+    }
+
+    let result = validateItem(x, item);
+    updateErrors((draft) => {
+      draft[item.name] = result;
+    });
+  };
+
+  let updateItem = (x: any, item: IMesonFieldItemHasValue) => {
+    updateForm((draft: { [k: string]: any }) => {
+      draft[item.name] = x;
+    });
+    setModified(true);
+    if (item.onChange != null) {
+      item.onChange(x);
+    }
+    if (props.onFieldChange != null) {
+      props.onFieldChange(item.name, x, form);
+    }
+  };
+
+  /** forcely */
+  let forcelyResetForm = (newForm: any) => {
+    updateForm((draft) => {
+      return newForm;
+    });
+  };
+
+  return {
+    formAny: form,
+    errors,
+    isModified: modified,
+    onCheckSubmit,
+    onCheckSubmitWithValue,
+    checkItem,
+    checkItemWithValue,
+    updateItem,
+    forcelyResetForm,
+  };
+};

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -32,6 +32,8 @@ export interface IMesonFieldBaseProps<K = string> {
 export interface IMesonInputField<K = string> extends IMesonFieldBaseProps {
   name: K;
   type: EMesonFieldType.Input;
+  /** real type property on <input/> */
+  inputType?: string;
   placeholder?: string;
   onChange?: (text: string) => void;
   textarea?: boolean;


### PR DESCRIPTION
Demo http://fe.jimu.io/meson-form/#wrap-meson-core

`useMesonCore` is a hooks for maintaining states of the form. It's more reusable than form components.

`useMesonCore` 用来维护 Form 的状态, 暴露出 `form`, `errors` 和操作方法, 这样 UI 部分可以在复用逻辑的情况下, 任意定制界面样式. 这里主要复用了校验的逻辑. 不过封装当中会用到一些底层 API. 一般场景还是建议封装以后再使用.

Plus, add `inputType` property to Input fields for specifying password.
