### PR TITLE
Custom field for multiple properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ export let MesonForm: SFC<{
 `useMesonCore` is a low level API for maintaining form states. The UI part need extra code.
 
 ```ts
-let { formAny, errors, onCheckSubmit, checkItem, updateItem, forcelyResetForm } = useMesonCore({
+let { formAny, errors, onCheckSubmit, checkItem, updateItem } = useMesonCore({
   initialValue: submittedForm,
   items: formItems,
   onSubmit: onSubmit,

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ export let MesonForm: SFC<{
   initialValue: any;
   /** JSON 结构的表单定义, 建议定义变量传过来, 一来定义会比较长, 二来 TS 类型推断在变量加类型的情况才准确 */
   items: IMesonFieldItem[];
-  onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: ISimpleObject) => void) => void;
+  onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: IMesonErrors) => void) => void;
   onCancel?: () => void;
   className?: string;
   style?: CSSProperties;

--- a/example/controller/generated-router.ts
+++ b/example/controller/generated-router.ts
@@ -61,6 +61,12 @@ export let genRouter = {
     path: () => `/custom`,
     go: () => switchPath(`/custom`),
   },
+  customMultiple: {
+    name: "custom-multiple",
+    raw: "custom-multiple",
+    path: () => `/custom-multiple`,
+    go: () => switchPath(`/custom-multiple`),
+  },
   wrapMesonCore: {
     name: "wrap-meson-core",
     raw: "wrap-meson-core",

--- a/example/forms/custom-multiple.tsx
+++ b/example/forms/custom-multiple.tsx
@@ -1,0 +1,87 @@
+import React, { SFC, useState } from "react";
+import { css, cx } from "emotion";
+import { MesonForm } from "../../src/form";
+import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { row } from "@jimengio/shared-utils";
+import DataPreview from "kits/data-preview";
+import SourceLink from "kits/source-link";
+import Input from "antd/lib/input";
+
+interface IDemo {
+  a: string;
+  b: string;
+}
+
+let formItems: IMesonFieldItem[] = [
+  {
+    type: EMesonFieldType.CustomMultiple,
+    names: ["a", "b"],
+    label: "自定义",
+    required: true,
+    validateMultiple: (form) => {
+      return {
+        a: form.a ? null : "a is required",
+        b: form.b ? null : "b is required",
+      };
+    },
+    renderFormWithModifiers: (form: IDemo, onChange, onCheck) => {
+      return (
+        <div className={row}>
+          <div>
+            Custome input
+            <Input
+              value={form.a}
+              onChange={(event) => {
+                let text = event.target.value;
+                onChange((draft) => {
+                  draft.a = text;
+                });
+              }}
+              placeholder={"Custom field a"}
+              onBlur={() => {
+                onCheck(form);
+              }}
+            />
+            <Input
+              value={form.b}
+              onChange={(event) => {
+                let text = event.target.value;
+                onChange((draft) => {
+                  draft.b = text;
+                });
+              }}
+              placeholder={"Custom field b"}
+              onBlur={() => {
+                onCheck(form);
+              }}
+            />
+          </div>
+        </div>
+      );
+    },
+  },
+];
+
+let CustomMultiplePage: SFC<{}> = (props) => {
+  let [form, setForm] = useState({});
+
+  return (
+    <div className={cx(row, styleContainer)}>
+      <MesonForm
+        initialValue={form}
+        items={formItems}
+        onSubmit={(form) => {
+          setForm(form);
+        }}
+      />
+      <div>
+        <SourceLink fileName={"custom.tsx"} />
+        <DataPreview data={form} />
+      </div>
+    </div>
+  );
+};
+
+export default CustomMultiplePage;
+
+let styleContainer = css``;

--- a/example/forms/custom-multiple.tsx
+++ b/example/forms/custom-multiple.tsx
@@ -25,7 +25,7 @@ let formItems: IMesonFieldItem<keyof IDemo>[] = [
         b: form.b ? null : "b is required",
       };
     },
-    renderMultiple: (form: IDemo, onChange: FuncMesonModifyForm<IDemo>, onCheck) => {
+    renderMultiple: (form: IDemo, modifyForm: FuncMesonModifyForm<IDemo>, checkForm) => {
       return (
         <div className={row}>
           <div>
@@ -34,26 +34,26 @@ let formItems: IMesonFieldItem<keyof IDemo>[] = [
               value={form.a}
               onChange={(event) => {
                 let text = event.target.value;
-                onChange((draft) => {
+                modifyForm((draft) => {
                   draft.a = text;
                 });
               }}
               placeholder={"Custom field a"}
               onBlur={() => {
-                onCheck(form);
+                checkForm(form);
               }}
             />
             <Input
               value={form.b}
               onChange={(event) => {
                 let text = event.target.value;
-                onChange((draft) => {
+                modifyForm((draft) => {
                   draft.b = text;
                 });
               }}
               placeholder={"Custom field b"}
               onBlur={() => {
-                onCheck(form);
+                checkForm(form);
               }}
             />
           </div>

--- a/example/forms/custom-multiple.tsx
+++ b/example/forms/custom-multiple.tsx
@@ -25,7 +25,7 @@ let formItems: IMesonFieldItem<keyof IDemo>[] = [
         b: form.b ? null : "b is required",
       };
     },
-    renderMultiple: (form: IDemo, modifyForm: FuncMesonModifyForm<IDemo>, checkForm) => {
+    renderMultiple: (form: IDemo, modifyForm: FuncMesonModifyForm<IDemo>, checkForm: (changedValues: IDemo) => void) => {
       return (
         <div className={row}>
           <div>
@@ -34,12 +34,15 @@ let formItems: IMesonFieldItem<keyof IDemo>[] = [
               value={form.a}
               onChange={(event) => {
                 let text = event.target.value;
+
+                // modify value on form
                 modifyForm((draft) => {
                   draft.a = text;
                 });
               }}
               placeholder={"Custom field a"}
               onBlur={() => {
+                // trigger validation, which is validationMultiple
                 checkForm(form);
               }}
             />
@@ -47,12 +50,15 @@ let formItems: IMesonFieldItem<keyof IDemo>[] = [
               value={form.b}
               onChange={(event) => {
                 let text = event.target.value;
+
+                // modify another value on form
                 modifyForm((draft) => {
                   draft.b = text;
                 });
               }}
               placeholder={"Custom field b"}
               onBlur={() => {
+                // trigger same validation
                 checkForm(form);
               }}
             />

--- a/example/forms/custom-multiple.tsx
+++ b/example/forms/custom-multiple.tsx
@@ -1,18 +1,19 @@
 import React, { SFC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "../../src/form";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem, EMesonFieldType, FuncMesonModifyForm } from "../../src/model/types";
 import { row } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import SourceLink from "kits/source-link";
 import Input from "antd/lib/input";
+import { Draft } from "immer";
 
 interface IDemo {
   a: string;
   b: string;
 }
 
-let formItems: IMesonFieldItem[] = [
+let formItems: IMesonFieldItem<keyof IDemo>[] = [
   {
     type: EMesonFieldType.CustomMultiple,
     names: ["a", "b"],
@@ -24,7 +25,7 @@ let formItems: IMesonFieldItem[] = [
         b: form.b ? null : "b is required",
       };
     },
-    renderFormWithModifiers: (form: IDemo, onChange, onCheck) => {
+    renderMultiple: (form: IDemo, onChange: FuncMesonModifyForm<IDemo>, onCheck) => {
       return (
         <div className={row}>
           <div>

--- a/example/forms/wrap-meson-core.tsx
+++ b/example/forms/wrap-meson-core.tsx
@@ -35,7 +35,7 @@ let WrapMesonCore: FC<{}> = (props) => {
     setSubmittedForm(form);
   };
 
-  let { formAny, errors, onCheckSubmit, checkItem, updateItem, forcelyResetForm } = useMesonCore({
+  let { formAny, errors, onCheckSubmit, checkItem, updateItem, updateForm, updateErrors } = useMesonCore({
     initialValue: submittedForm,
     items: formItems,
     onSubmit: onSubmit,
@@ -55,7 +55,12 @@ let WrapMesonCore: FC<{}> = (props) => {
         <button
           onClick={() => {
             setSubmittedForm({});
-            forcelyResetForm({});
+            updateForm((draft) => {
+              return {};
+            });
+            updateErrors((draft) => {
+              return {};
+            });
           }}
         >
           Reset

--- a/example/models/router-rules.ts
+++ b/example/models/router-rules.ts
@@ -11,6 +11,7 @@ export const routerRules: IRouteRule[] = [
   { path: "select" },
   { path: "validation" },
   { path: "custom" },
+  { path: "custom-multiple" },
   { path: "wrap-meson-core" },
   { path: "forward-form" },
   { path: "modify-on-change" },

--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -18,6 +18,7 @@ import SwitchPage from "forms/switch";
 import InlineFormPage from "forms/inline-form";
 import FormBlankLabel from "forms/blank-label";
 import DrawerPage from "forms/drawer";
+import CustomMultiplePage from "forms/custom-multiple";
 
 let pages: { title: string; path: string }[] = [
   {
@@ -47,6 +48,10 @@ let pages: { title: string; path: string }[] = [
   {
     title: "Custom",
     path: genRouter.custom.name,
+  },
+  {
+    title: "Custom multiple",
+    path: genRouter.customMultiple.name,
   },
   {
     title: "Auto save",
@@ -95,6 +100,8 @@ let Container: SFC<{ router: IRouteParseResult }> = (props) => {
         return <ValidationPage />;
       case genRouter.custom.name:
         return <CustomPage />;
+      case genRouter.customMultiple.name:
+        return <CustomMultiplePage />;
       case genRouter.autoSave.name:
         return <AutoSavePage />;
       case genRouter.wrapMesonCore.name:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.1.23",
+  "version": "0.2.0-a1",
   "description": "",
   "main": "./lib/form.js",
   "types": "./lib/form.d.ts",

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -16,6 +16,7 @@ import MesonModal from "./component/modal";
 import TextArea from "antd/lib/input/TextArea";
 import produce, { Draft } from "immer";
 import MesonDrawer from "./component/drawer";
+import { useMesonCore } from "./hook/meson-core";
 
 /**
  * 清空draft对象的value值
@@ -51,9 +52,25 @@ export interface MesonFormProps {
 }
 
 export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonFormProps> = (props, ref) => {
-  let [form, updateForm] = useImmer(props.initialValue);
-  let [errors, updateErrors] = useImmer({});
   let [modified, setModified] = useState<boolean>(false);
+
+  let {
+    formAny: form,
+    updateForm,
+    errors,
+    updateErrors,
+    onCheckSubmit,
+    checkItem,
+    onCheckSubmitWithValue,
+    updateItem,
+    checkItemWithValue,
+    forcelyResetForm,
+  } = useMesonCore({
+    initialValue: props.initialValue,
+    items: props.items,
+    submitOnEdit: props.submitOnEdit,
+    onSubmit: props.onSubmit,
+  });
 
   /**
    * 父组件可以通过ref调用onSubmit、onReset
@@ -72,81 +89,6 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
       }
     },
   }));
-
-  let onCheckSubmitWithValue = (specifiedForm?: { [k: string]: any }) => {
-    let latestForm = specifiedForm;
-    let currentErrors: ISimpleObject = {};
-    let hasErrors = false;
-    traverseItems(props.items, (item: IMesonFieldItemHasValue) => {
-      if (item.shouldHide != null && item.shouldHide(latestForm)) {
-        return null;
-      }
-
-      let result = validateItem(latestForm[item.name], item);
-
-      if (result != null) {
-        currentErrors[item.name] = result;
-        hasErrors = true;
-      }
-    });
-
-    updateErrors((draft: ISimpleObject) => {
-      return currentErrors;
-    });
-
-    if (!hasErrors) {
-      props.onSubmit(latestForm, (serverErrors) => {
-        updateErrors((draft: ISimpleObject) => {
-          return serverErrors;
-        });
-      });
-      setModified(false);
-    }
-  };
-
-  let onCheckSubmit = () => {
-    onCheckSubmitWithValue(form);
-  };
-
-  let checkItem = (item: IMesonFieldItemHasValue) => {
-    if (props.submitOnEdit) {
-      onCheckSubmitWithValue(form);
-      return;
-    }
-
-    let result = validateItem(form[item.name], item);
-    updateErrors((draft) => {
-      draft[item.name] = result;
-    });
-  };
-
-  let checkItemWithValue = (x: any, item: IMesonFieldItemHasValue) => {
-    if (props.submitOnEdit) {
-      let newForm = produce(form, (draft) => {
-        draft[item.name] = x;
-      });
-      onCheckSubmitWithValue(newForm);
-      return;
-    }
-
-    let result = validateItem(x, item);
-    updateErrors((draft) => {
-      draft[item.name] = result;
-    });
-  };
-
-  let updateItem = (x: any, item: IMesonFieldItemHasValue) => {
-    updateForm((draft: { [k: string]: any }) => {
-      draft[item.name] = x;
-    });
-    setModified(true);
-    if (item.onChange != null) {
-      item.onChange(x, updateForm);
-    }
-    if (props.onFieldChange != null) {
-      props.onFieldChange(item.name, x, form, updateForm);
-    }
-  };
 
   let renderValueItem = (item: IMesonFieldItem) => {
     switch (item.type) {

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -50,8 +50,6 @@ export interface MesonFormProps {
 }
 
 export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonFormProps> = (props, ref) => {
-  let [modified, setModified] = useState<boolean>(false);
-
   let {
     formAny: form,
     updateForm,
@@ -63,6 +61,7 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
     updateItem,
     checkItemWithValue,
     checkItemCustomMultiple,
+    resetModified,
   } = useMesonCore({
     initialValue: props.initialValue,
     items: props.items,
@@ -80,7 +79,7 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
     onReset: () => {
       updateForm(clearDraftValue);
       updateErrors(clearDraftValue);
-      setModified(false);
+      resetModified();
 
       if (props.onReset != null) {
         props.onReset();

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -62,7 +62,6 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
     onCheckSubmitWithValue,
     updateItem,
     checkItemWithValue,
-    forcelyResetForm,
     checkItemCustomMultiple,
   } = useMesonCore({
     initialValue: props.initialValue,

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -5,11 +5,8 @@ import Input from "antd/lib/input";
 import Switch from "antd/lib/switch";
 import Select from "antd/lib/select";
 import InputNumber from "antd/lib/input-number";
-import { useImmer } from "use-immer";
 import { lingual, formatString } from "./lingual";
-import { IMesonFieldItem, EMesonFieldType, IMesonFieldItemHasValue, ISimpleObject, FuncMesonModifyForm } from "./model/types";
-import { validateValueRequired, validateByMethods, validateItem } from "./util/validation";
-import { traverseItems } from "./util/render";
+import { IMesonFieldItem, EMesonFieldType, IMesonFieldItemHasValue, FuncMesonModifyForm, IMesonErrors } from "./model/types";
 import { RequiredMark } from "./component/misc";
 import { FormFooter, EMesonFooterLayout } from "./component/form-footer";
 import MesonModal from "./component/modal";
@@ -17,6 +14,7 @@ import TextArea from "antd/lib/input/TextArea";
 import produce, { Draft } from "immer";
 import MesonDrawer from "./component/drawer";
 import { useMesonCore } from "./hook/meson-core";
+import { showErrorByNames } from "./util/validation";
 
 /**
  * 清空draft对象的value值
@@ -38,7 +36,7 @@ export interface MesonFormHandler {
 export interface MesonFormProps {
   initialValue: any;
   items: IMesonFieldItem[];
-  onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: ISimpleObject) => void) => void;
+  onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: IMesonErrors) => void) => void;
   onReset?: () => void;
   onCancel?: () => void;
   className?: string;
@@ -65,7 +63,7 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
     updateItem,
     checkItemWithValue,
     forcelyResetForm,
-    checkItemHighlyCustomized,
+    checkItemCustomMultiple,
   } = useMesonCore({
     initialValue: props.initialValue,
     items: props.items,
@@ -261,17 +259,17 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
         );
       }
 
-      if (item.type === EMesonFieldType.HighlyCustomized) {
+      if (item.type === EMesonFieldType.CustomMultiple) {
         let formModifider: FuncMesonModifyForm = (f) => {
           updateForm(f);
         };
 
         let onCheckValues = (xs: any) => {
-          checkItemHighlyCustomized(xs, item);
+          checkItemCustomMultiple(xs, item);
         };
 
         // errors related to multiple fields, need to extract
-        let error = item.extractError(errors);
+        let error = showErrorByNames(errors, item.names);
         let errorNode = error != null ? <div className={styleError}>{error}</div> : null;
 
         return (
@@ -320,7 +318,7 @@ export let MesonFormModal: SFC<{
   visible: boolean;
   initialValue: { [k: string]: any };
   items: IMesonFieldItem[];
-  onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: ISimpleObject) => void) => void;
+  onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: IMesonErrors) => void) => void;
   onClose: () => void;
   isLoading?: boolean;
   hideClose?: boolean;
@@ -357,7 +355,7 @@ export let MesonFormDrawer: SFC<{
   width?: number;
   initialValue: { [k: string]: any };
   items: IMesonFieldItem[];
-  onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: ISimpleObject) => void) => void;
+  onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: IMesonErrors) => void) => void;
   onClose: () => void;
   isLoading?: boolean;
   hideClose?: boolean;

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -260,11 +260,11 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
       }
 
       if (item.type === EMesonFieldType.CustomMultiple) {
-        let formModifider: FuncMesonModifyForm = (f) => {
+        let modifidForm: FuncMesonModifyForm = (f) => {
           updateForm(f);
         };
 
-        let onCheckValues = (xs: any) => {
+        let checkForm = (xs: any) => {
           checkItemCustomMultiple(xs, item);
         };
 
@@ -276,7 +276,7 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
           <div key={idx} className={cx(row, styleItemRow)}>
             {labelNode}
             <div className={cx(flex, column, styleValueArea, item.className)} style={item.style}>
-              {item.renderFormWithModifiers(form, formModifider, onCheckValues)}
+              {item.renderMultiple(form, modifidForm, checkForm)}
               <div className={styleErrorWrapper}>{errorNode}</div>
             </div>
           </div>

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -7,7 +7,7 @@ import Select from "antd/lib/select";
 import InputNumber from "antd/lib/input-number";
 import { useImmer } from "use-immer";
 import { lingual, formatString } from "./lingual";
-import { IMesonFieldItem, EMesonFieldType, IMesonFieldItemHasValue, ISimpleObject, FuncMesonModifyForm } from "./model/types";
+import { IMesonFieldItem, EMesonFieldType, IMesonFieldItemHasValue, ISimpleObject, FuncMesonModifyForm, FuncMesonModifyErrors } from "./model/types";
 import { validateValueRequired, validateByMethods, validateItem } from "./util/validation";
 import { traverseItems } from "./util/render";
 import { RequiredMark } from "./component/misc";
@@ -312,6 +312,30 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
             {labelNode}
             <div className={cx(flex, column, styleValueArea, item.className)} style={item.style}>
               {item.render(form[item.name], onChange, form, onCheck)}
+              <div className={styleErrorWrapper}>{errorNode}</div>
+            </div>
+          </div>
+        );
+      }
+
+      if (item.type === EMesonFieldType.HighlyCustomized) {
+        let formModifider: FuncMesonModifyForm = (f) => {
+          updateForm(f);
+        };
+
+        let errorsModifier: FuncMesonModifyErrors = (f) => {
+          updateErrors(f);
+        };
+
+        // errors related to multiple fields, need to extract
+        let error = item.extractError(errors);
+        let errorNode = error != null ? <div className={styleError}>{error}</div> : null;
+
+        return (
+          <div key={idx} className={cx(row, styleItemRow)}>
+            {labelNode}
+            <div className={cx(flex, column, styleValueArea, item.className)} style={item.style}>
+              {item.renderFormWithModifiers(form, formModifider, errorsModifier)}
               <div className={styleErrorWrapper}>{errorNode}</div>
             </div>
           </div>

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -7,7 +7,7 @@ import Select from "antd/lib/select";
 import InputNumber from "antd/lib/input-number";
 import { useImmer } from "use-immer";
 import { lingual, formatString } from "./lingual";
-import { IMesonFieldItem, EMesonFieldType, IMesonFieldItemHasValue, ISimpleObject, FuncMesonModifyForm, FuncMesonModifyErrors } from "./model/types";
+import { IMesonFieldItem, EMesonFieldType, IMesonFieldItemHasValue, ISimpleObject, FuncMesonModifyForm } from "./model/types";
 import { validateValueRequired, validateByMethods, validateItem } from "./util/validation";
 import { traverseItems } from "./util/render";
 import { RequiredMark } from "./component/misc";
@@ -65,6 +65,7 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
     updateItem,
     checkItemWithValue,
     forcelyResetForm,
+    checkItemHighlyCustomized,
   } = useMesonCore({
     initialValue: props.initialValue,
     items: props.items,
@@ -265,8 +266,8 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
           updateForm(f);
         };
 
-        let errorsModifier: FuncMesonModifyErrors = (f) => {
-          updateErrors(f);
+        let onCheckValues = (xs: any) => {
+          checkItemHighlyCustomized(xs, item);
         };
 
         // errors related to multiple fields, need to extract
@@ -277,7 +278,7 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
           <div key={idx} className={cx(row, styleItemRow)}>
             {labelNode}
             <div className={cx(flex, column, styleValueArea, item.className)} style={item.style}>
-              {item.renderFormWithModifiers(form, formModifider, errorsModifier)}
+              {item.renderFormWithModifiers(form, formModifider, onCheckValues)}
               <div className={styleErrorWrapper}>{errorNode}</div>
             </div>
           </div>

--- a/src/hook/meson-core.ts
+++ b/src/hook/meson-core.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useImmer } from "use-immer";
-import { IMesonFieldItem, EMesonFieldType, IMesonFieldItemHasValue, ISimpleObject } from "../model/types";
+import { IMesonFieldItem, EMesonFieldType, IMesonFieldItemHasValue, ISimpleObject, FuncMesonModifyForm } from "../model/types";
 import { validateValueRequired, validateByMethods, validateItem } from "../util/validation";
 import { traverseItems } from "../util/render";
 import produce from "immer";
@@ -10,7 +10,7 @@ export let useMesonCore = (props: {
   initialValue: any;
   items: IMesonFieldItem[];
   onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: ISimpleObject) => void) => void;
-  onFieldChange?: (name: string, v: any, prevForm?: { [k: string]: any }) => void;
+  onFieldChange?: (name: string, v: any, prevForm?: { [k: string]: any }, modifyFormObject?: FuncMesonModifyForm) => void;
   submitOnEdit?: boolean;
 }) => {
   let [form, updateForm] = useImmer(props.initialValue);
@@ -85,10 +85,10 @@ export let useMesonCore = (props: {
     });
     setModified(true);
     if (item.onChange != null) {
-      item.onChange(x);
+      item.onChange(x, updateForm);
     }
     if (props.onFieldChange != null) {
-      props.onFieldChange(item.name, x, form);
+      props.onFieldChange(item.name, x, form, updateForm);
     }
   };
 
@@ -101,7 +101,9 @@ export let useMesonCore = (props: {
 
   return {
     formAny: form,
+    updateForm,
     errors,
+    updateErrors,
     isModified: modified,
     onCheckSubmit,
     onCheckSubmitWithValue,

--- a/src/hook/meson-core.ts
+++ b/src/hook/meson-core.ts
@@ -117,5 +117,8 @@ export let useMesonCore = (props: {
     checkItemCustomMultiple,
     checkItemWithValue,
     updateItem,
+    resetModified: () => {
+      modifiedState.current = false;
+    },
   };
 };

--- a/src/inline-form.tsx
+++ b/src/inline-form.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { useMesonCore } from "./hook/meson-core";
-import { IMesonCustomField, EMesonFieldType, IMesonFieldItem, EMesonValidate, ISimpleObject, FuncMesonModifyForm } from "./model/types";
+import { IMesonCustomField, EMesonFieldType, IMesonFieldItem, EMesonValidate, FuncMesonModifyForm, IMesonErrors } from "./model/types";
 import { column, row } from "@jimengio/shared-utils";
 import { CSSProperties } from "@emotion/serialize";
 import Input from "antd/lib/input";
@@ -13,7 +13,7 @@ import { RequiredMark } from "./component/misc";
 let MesonInlineForm: FC<{
   initialValue: any;
   items: IMesonFieldItem[];
-  onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: ISimpleObject) => void) => void;
+  onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: IMesonErrors) => void) => void;
   onReset?: () => void;
   onCancel?: () => void;
   className?: string;
@@ -125,7 +125,7 @@ let MesonInlineForm: FC<{
           return `Not supported type: ${item.type}`;
         }
 
-        if (item.type === EMesonFieldType.HighlyCustomized) {
+        if (item.type === EMesonFieldType.CustomMultiple) {
           return `Not supported type: ${item.type}`;
         }
 

--- a/src/inline-form.tsx
+++ b/src/inline-form.tsx
@@ -125,6 +125,10 @@ let MesonInlineForm: FC<{
           return `Not supported type: ${item.type}`;
         }
 
+        if (item.type === EMesonFieldType.HighlyCustomized) {
+          return `Not supported type: ${item.type}`;
+        }
+
         let name: string = item.name;
         let error = name != null ? errors[name] : null;
         let errorNode = error != null ? <span className={styleError}>{error}</span> : null;

--- a/src/inline-form.tsx
+++ b/src/inline-form.tsx
@@ -25,7 +25,7 @@ let MesonInlineForm: FC<{
     props.onSubmit(form);
   };
 
-  let { formAny, errors, onCheckSubmit, checkItem, updateItem, forcelyResetForm, checkItemWithValue } = useMesonCore({
+  let { formAny, errors, onCheckSubmit, checkItem, updateItem, checkItemWithValue } = useMesonCore({
     initialValue: props.initialValue,
     items: props.items,
     onSubmit: onSubmit,

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -18,12 +18,14 @@ export type FuncMesonValidator = (x: any, item?: IMesonFieldItemHasValue) => str
  * Caution, it does not trigger field validation! So don't use it to mofidy fields before current one.
  */
 export type FuncMesonModifyForm<T = any> = (modifter: (form: T) => void) => void;
+export type FuncMesonModifyErrors = (modifter: (errors: ISimpleObject) => void) => void;
 
 export enum EMesonFieldType {
   Input = "input",
   Number = "number",
   Select = "select",
   Custom = "custom",
+  HighlyCustomized = "highly-custimized",
   Group = "group",
   Switch = "switch",
   // like React fragment
@@ -109,6 +111,12 @@ export interface IMesonCustomField<K> extends IMesonFieldBaseProps {
   validator?: FuncMesonValidator;
 }
 
+export interface IMesonHighlyCustomizedField extends IMesonFieldBaseProps {
+  type: EMesonFieldType.HighlyCustomized;
+  renderFormWithModifiers: (form: any, onModifyForm: FuncMesonModifyForm, onModifyErrors: FuncMesonModifyErrors) => ReactNode;
+  extractError: (errors: ISimpleObject) => string;
+}
+
 export interface IMesonGroupField extends IMesonFieldBaseProps {
   type: EMesonFieldType.Group;
   children: IMesonFieldItem[];
@@ -134,4 +142,5 @@ export type IMesonFieldItem<K = string> =
   | IMesonCustomField<K>
   | IMesonSwitchField<K>
   | IMesonGroupField
-  | IMesonFieldsFragment;
+  | IMesonFieldsFragment
+  | IMesonHighlyCustomizedField;

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -18,7 +18,6 @@ export type FuncMesonValidator = (x: any, item?: IMesonFieldItemHasValue) => str
  * Caution, it does not trigger field validation! So don't use it to mofidy fields before current one.
  */
 export type FuncMesonModifyForm<T = any> = (modifter: (form: T) => void) => void;
-export type FuncMesonModifyErrors = (modifter: (errors: ISimpleObject) => void) => void;
 
 export enum EMesonFieldType {
   Input = "input",
@@ -111,10 +110,12 @@ export interface IMesonCustomField<K> extends IMesonFieldBaseProps {
   validator?: FuncMesonValidator;
 }
 
-export interface IMesonHighlyCustomizedField extends IMesonFieldBaseProps {
+export interface IMesonFieldHighlyCustomized extends IMesonFieldBaseProps {
   type: EMesonFieldType.HighlyCustomized;
-  renderFormWithModifiers: (form: any, onModifyForm: FuncMesonModifyForm, onModifyErrors: FuncMesonModifyErrors) => ReactNode;
+  names: string[];
+  renderFormWithModifiers: (form: any, onModifyForm: FuncMesonModifyForm, onCheck: (xs: any) => void) => ReactNode;
   extractError: (errors: ISimpleObject) => string;
+  validateRelated: (form: any, item: IMesonFieldHighlyCustomized) => ISimpleObject;
 }
 
 export interface IMesonGroupField extends IMesonFieldBaseProps {
@@ -143,4 +144,4 @@ export type IMesonFieldItem<K = string> =
   | IMesonSwitchField<K>
   | IMesonGroupField
   | IMesonFieldsFragment
-  | IMesonHighlyCustomizedField;
+  | IMesonFieldHighlyCustomized;

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -122,7 +122,7 @@ export interface IMesonFieldCustomMultiple<K = string> extends IMesonFieldBasePr
    */
   names: K[];
   /** get form and render into form item */
-  renderMultiple: (form: any, modifyForm: FuncMesonModifyForm, checkForm: (xs: any) => void) => ReactNode;
+  renderMultiple: (form: any, modifyForm: FuncMesonModifyForm, checkForm: (changedValues: any) => void) => ReactNode;
   /** get form and return errors of related fields in object */
   validateMultiple: (form: any, item: IMesonFieldCustomMultiple<K>) => IMesonErrors;
 }

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -114,11 +114,17 @@ export interface IMesonCustomField<K> extends IMesonFieldBaseProps {
   validator?: FuncMesonValidator;
 }
 
-export interface IMesonFieldCustomMultiple extends IMesonFieldBaseProps {
+export interface IMesonFieldCustomMultiple<K = string> extends IMesonFieldBaseProps {
   type: EMesonFieldType.CustomMultiple;
-  names: string[];
-  renderFormWithModifiers: (form: any, onModifyForm: FuncMesonModifyForm, onCheck: (xs: any) => void) => ReactNode;
-  validateMultiple: (form: any, item: IMesonFieldCustomMultiple) => IMesonErrors;
+  /** multiple fields to edit and to check
+   * @param modifyForm accepts a function to modify the form
+   * @param checkForm accepts an object of new values
+   */
+  names: K[];
+  /** get form and render into form item */
+  renderMultiple: (form: any, modifyForm: FuncMesonModifyForm, checkForm: (xs: any) => void) => ReactNode;
+  /** get form and return errors of related fields in object */
+  validateMultiple: (form: any, item: IMesonFieldCustomMultiple<K>) => IMesonErrors;
 }
 
 export interface IMesonGroupField extends IMesonFieldBaseProps {
@@ -147,4 +153,4 @@ export type IMesonFieldItem<K = string> =
   | IMesonSwitchField<K>
   | IMesonGroupField
   | IMesonFieldsFragment
-  | IMesonFieldCustomMultiple;
+  | IMesonFieldCustomMultiple<K>;

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -2,7 +2,11 @@ import { ReactNode } from "react";
 import { InputProps } from "antd/lib/input";
 import { SelectProps } from "antd/lib/select";
 
-export interface ISimpleObject {
+export interface ISimpleObject<T = any> {
+  [k: string]: T;
+}
+
+export interface IMesonErrors {
   [k: string]: string;
 }
 
@@ -24,7 +28,7 @@ export enum EMesonFieldType {
   Number = "number",
   Select = "select",
   Custom = "custom",
-  HighlyCustomized = "highly-custimized",
+  CustomMultiple = "custom-multiple",
   Group = "group",
   Switch = "switch",
   // like React fragment
@@ -110,12 +114,11 @@ export interface IMesonCustomField<K> extends IMesonFieldBaseProps {
   validator?: FuncMesonValidator;
 }
 
-export interface IMesonFieldHighlyCustomized extends IMesonFieldBaseProps {
-  type: EMesonFieldType.HighlyCustomized;
+export interface IMesonFieldCustomMultiple extends IMesonFieldBaseProps {
+  type: EMesonFieldType.CustomMultiple;
   names: string[];
   renderFormWithModifiers: (form: any, onModifyForm: FuncMesonModifyForm, onCheck: (xs: any) => void) => ReactNode;
-  extractError: (errors: ISimpleObject) => string;
-  validateRelated: (form: any, item: IMesonFieldHighlyCustomized) => ISimpleObject;
+  validateMultiple: (form: any, item: IMesonFieldCustomMultiple) => IMesonErrors;
 }
 
 export interface IMesonGroupField extends IMesonFieldBaseProps {
@@ -144,4 +147,4 @@ export type IMesonFieldItem<K = string> =
   | IMesonSwitchField<K>
   | IMesonGroupField
   | IMesonFieldsFragment
-  | IMesonFieldHighlyCustomized;
+  | IMesonFieldCustomMultiple;

--- a/src/util/render.ts
+++ b/src/util/render.ts
@@ -3,7 +3,7 @@ import { IMesonFieldItem, EMesonFieldType } from "../model/types";
 export let traverseItems = (xs: IMesonFieldItem[], method: (x: IMesonFieldItem) => void) => {
   xs.forEach((x) => {
     switch (x.type) {
-      case EMesonFieldType.HighlyCustomized:
+      case EMesonFieldType.CustomMultiple:
         return;
       case EMesonFieldType.Group:
       case EMesonFieldType.Fragment:
@@ -14,10 +14,10 @@ export let traverseItems = (xs: IMesonFieldItem[], method: (x: IMesonFieldItem) 
   });
 };
 
-export let traverseItemsReachHighlyCustomized = (xs: IMesonFieldItem[], method: (x: IMesonFieldItem) => void) => {
+export let traverseItemsReachCustomMultiple = (xs: IMesonFieldItem[], method: (x: IMesonFieldItem) => void) => {
   xs.forEach((x) => {
     switch (x.type) {
-      case EMesonFieldType.HighlyCustomized:
+      case EMesonFieldType.CustomMultiple:
         method(x);
         return;
       case EMesonFieldType.Group:

--- a/src/util/render.ts
+++ b/src/util/render.ts
@@ -1,28 +1,35 @@
-import { IMesonFieldItem, EMesonFieldType } from "../model/types";
+import { IMesonFieldItem, EMesonFieldType, ISimpleObject } from "../model/types";
 
-export let traverseItems = (xs: IMesonFieldItem[], method: (x: IMesonFieldItem) => void) => {
+export let traverseItems = (xs: IMesonFieldItem[], form: ISimpleObject, method: (x: IMesonFieldItem) => void) => {
   xs.forEach((x) => {
+    if (x.shouldHide != null && x.shouldHide(form)) {
+      return null;
+    }
+
     switch (x.type) {
       case EMesonFieldType.CustomMultiple:
         return;
       case EMesonFieldType.Group:
       case EMesonFieldType.Fragment:
-        traverseItems(x.children, method);
+        traverseItems(x.children, form, method);
       default:
         method(x);
     }
   });
 };
 
-export let traverseItemsReachCustomMultiple = (xs: IMesonFieldItem[], method: (x: IMesonFieldItem) => void) => {
+export let traverseItemsReachCustomMultiple = (xs: IMesonFieldItem[], form: ISimpleObject, method: (x: IMesonFieldItem) => void) => {
   xs.forEach((x) => {
+    if (x.shouldHide != null && x.shouldHide(form)) {
+      return null;
+    }
     switch (x.type) {
       case EMesonFieldType.CustomMultiple:
         method(x);
         return;
       case EMesonFieldType.Group:
       case EMesonFieldType.Fragment:
-        traverseItems(x.children, method);
+        traverseItems(x.children, form, method);
       default:
         return;
     }

--- a/src/util/render.ts
+++ b/src/util/render.ts
@@ -2,12 +2,29 @@ import { IMesonFieldItem, EMesonFieldType } from "../model/types";
 
 export let traverseItems = (xs: IMesonFieldItem[], method: (x: IMesonFieldItem) => void) => {
   xs.forEach((x) => {
-    if (x.type === EMesonFieldType.Group) {
-      traverseItems(x.children, method);
-    } else if (x.type === EMesonFieldType.Fragment) {
-      traverseItems(x.children, method);
-    } else {
-      method(x);
+    switch (x.type) {
+      case EMesonFieldType.HighlyCustomized:
+        return;
+      case EMesonFieldType.Group:
+      case EMesonFieldType.Fragment:
+        traverseItems(x.children, method);
+      default:
+        method(x);
+    }
+  });
+};
+
+export let traverseItemsReachHighlyCustomized = (xs: IMesonFieldItem[], method: (x: IMesonFieldItem) => void) => {
+  xs.forEach((x) => {
+    switch (x.type) {
+      case EMesonFieldType.HighlyCustomized:
+        method(x);
+        return;
+      case EMesonFieldType.Group:
+      case EMesonFieldType.Fragment:
+        traverseItems(x.children, method);
+      default:
+        return;
     }
   });
 };

--- a/src/util/render.ts
+++ b/src/util/render.ts
@@ -4,6 +4,8 @@ export let traverseItems = (xs: IMesonFieldItem[], method: (x: IMesonFieldItem) 
   xs.forEach((x) => {
     if (x.type === EMesonFieldType.Group) {
       traverseItems(x.children, method);
+    } else if (x.type === EMesonFieldType.Fragment) {
+      traverseItems(x.children, method);
     } else {
       method(x);
     }

--- a/src/util/render.ts
+++ b/src/util/render.ts
@@ -29,7 +29,7 @@ export let traverseItemsReachCustomMultiple = (xs: IMesonFieldItem[], form: ISim
         return;
       case EMesonFieldType.Group:
       case EMesonFieldType.Fragment:
-        traverseItems(x.children, form, method);
+        traverseItemsReachCustomMultiple(x.children, form, method);
       default:
         return;
     }

--- a/src/util/validation.ts
+++ b/src/util/validation.ts
@@ -1,4 +1,4 @@
-import { EMesonFieldType, IMesonFieldItem, IMesonFieldItemHasValue, EMesonValidate, FuncMesonValidator, ISimpleObject } from "../model/types";
+import { EMesonFieldType, IMesonFieldItem, IMesonFieldItemHasValue, EMesonValidate, FuncMesonValidator, IMesonErrors } from "../model/types";
 import { formatString, lingual } from "../lingual";
 import is from "is";
 
@@ -45,11 +45,20 @@ export let validateItem = (x: any, item: IMesonFieldItemHasValue): string => {
   return undefined;
 };
 
-export let hasErrorInObject = (x: ISimpleObject): boolean => {
+export let hasErrorInObject = (x: IMesonErrors): boolean => {
   for (let k in x) {
     if (x[k] != null) {
       return true;
     }
   }
   return false;
+};
+
+export let showErrorByNames = (x: IMesonErrors, names: string[]): string => {
+  for (let k in x) {
+    if (x[k] != null) {
+      return x[k];
+    }
+  }
+  return null;
 };

--- a/src/util/validation.ts
+++ b/src/util/validation.ts
@@ -1,4 +1,4 @@
-import { EMesonFieldType, IMesonFieldItem, IMesonFieldItemHasValue, EMesonValidate, FuncMesonValidator } from "../model/types";
+import { EMesonFieldType, IMesonFieldItem, IMesonFieldItemHasValue, EMesonValidate, FuncMesonValidator, ISimpleObject } from "../model/types";
 import { formatString, lingual } from "../lingual";
 import is from "is";
 
@@ -43,4 +43,13 @@ export let validateItem = (x: any, item: IMesonFieldItemHasValue): string => {
     return validateValueRequired(x, item);
   }
   return undefined;
+};
+
+export let hasErrorInObject = (x: ISimpleObject): boolean => {
+  for (let k in x) {
+    if (x[k] != null) {
+      return true;
+    }
+  }
+  return false;
 };


### PR DESCRIPTION

Example http://fe.jimu.io/meson-form/#custom-multiple

### New type  `EMesonFieldType.CustomMultiple`

Designed for rendering fields linked to multiple properties. See example at https://github.com/jimengio/meson-form/blob/custom-multiple/example/forms/custom-multiple.tsx#L16-L70 .

Validation should also be work even it’s related to multiple properties.

`CustomMultiple` 用于渲染一个组件对应到多个字段的 UI, 同时, 原有的提交时校验, 以及编辑完成时触发校验这个逻辑依然要正常运行. 目前的实现基本满足要求, 类型约束的细节需要后续完善.

### Refactoring

* Some duplicated functions in `form.tsx` has been merged into `meson-core.ts` for reuse.
* Some changes on types and naming. But they should not affect users.
