### PR TITLE
rename group type to reduce confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Props for `MesonFormDrawer` is almost same to `MesonFormModal`.
 - `Select`, 单选菜单, 需要传入 JSON 结构的 `options` 参数,
 - `Switch`, 开关类型,
 - `Custom`, 自定义渲染, 需要定义渲染函数, 基于给出的表单的值和 `onChange` 函数进行渲染,
-- `Group`, 嵌套的分组,
-- `Fragment`, 类似 Group 但是这个分组不进行嵌套, 用在属性批量控制显示隐藏的情况.
+- `Group`, 不嵌套的分组, 用在属性批量控制显示隐藏的情况,
+- `Nested`, 嵌套的分组.
 
 对于自定义渲染的位置, 配置 `Custom` 类型, 并且需要传入一个 `render` 方法用于渲染值以及操作区域,
 

--- a/example/controller/generated-router.ts
+++ b/example/controller/generated-router.ts
@@ -103,6 +103,12 @@ export let genRouter = {
     path: () => `/blank-label`,
     go: () => switchPath(`/blank-label`),
   },
+  group: {
+    name: "group",
+    raw: "group",
+    path: () => `/group`,
+    go: () => switchPath(`/group`),
+  },
   _: {
     name: "home",
     raw: "",

--- a/example/forms/draft.tsx
+++ b/example/forms/draft.tsx
@@ -16,6 +16,7 @@ interface IDemo {
   name: string;
   size: number;
   description: string;
+  materialInside: string;
 }
 
 let options: IMesonSelectItem[] = [
@@ -83,7 +84,7 @@ let formItems: IMesonFieldItem<keyof IDemo>[] = [
     required: true,
   },
   {
-    type: EMesonFieldType.Fragment,
+    type: EMesonFieldType.Group,
     shouldHide: () => true,
     children: [
       {
@@ -104,8 +105,8 @@ let formItems: IMesonFieldItem<keyof IDemo>[] = [
     },
   },
   {
-    type: EMesonFieldType.Group,
-    label: "group",
+    type: EMesonFieldType.Nested,
+    label: "Nested",
     children: [{ type: EMesonFieldType.Select, label: "物料", name: "materialInside", required: true, options: options }],
   },
   {

--- a/example/forms/group.tsx
+++ b/example/forms/group.tsx
@@ -1,0 +1,107 @@
+import React, { FC, useState } from "react";
+import { css, cx } from "emotion";
+import { MesonForm } from "meson-form";
+import { EMesonFooterLayout } from "../../src/component/form-footer";
+import { IMesonSelectItem, IMesonFieldItem, EMesonFieldType, EMesonValidate } from "../../src/model/types";
+import Input from "antd/lib/input";
+import { row } from "@jimengio/shared-utils";
+import DataPreview from "kits/data-preview";
+import SourceLink from "kits/source-link";
+
+interface IDemo {
+  visibility: boolean;
+  a: string;
+  b: string;
+  c: string;
+  d: string;
+}
+
+let options: IMesonSelectItem[] = [
+  {
+    value: "1",
+    display: "one",
+  },
+  {
+    value: "2",
+    display: "two",
+  },
+];
+
+let formItems: IMesonFieldItem<keyof IDemo>[] = [
+  {
+    type: EMesonFieldType.Switch,
+    label: "Show/hide",
+    name: "visibility",
+  },
+  {
+    type: EMesonFieldType.Group,
+    shouldHide: (form) => form.visibility,
+    children: [
+      {
+        type: EMesonFieldType.Input,
+        label: "a",
+        name: "a",
+        required: true,
+      },
+      {
+        type: EMesonFieldType.Input,
+        textarea: true,
+        label: "b",
+        name: "b",
+        required: true,
+      },
+    ],
+  },
+  {
+    type: EMesonFieldType.Nested,
+    label: "Nested",
+    children: [
+      { type: EMesonFieldType.Select, label: "物料", name: "c", required: true, options: options },
+      { type: EMesonFieldType.Input, label: "d", name: "d" },
+    ],
+  },
+];
+
+let GroupPage: FC<{}> = (props) => {
+  let [form, setForm] = useState({});
+
+  return (
+    <div className={cx(row, styleContainer)}>
+      <div className={styleFormArea}>
+        <MesonForm
+          initialValue={form}
+          items={formItems}
+          onSubmit={(form) => {
+            setForm(form);
+          }}
+          onCancel={() => {
+            setForm({});
+          }}
+          footerLayout={EMesonFooterLayout.Center}
+          submitOnEdit={false}
+        />
+      </div>
+      <div>
+        <SourceLink fileName={"draft.tsx"} />
+        <DataPreview data={form} />
+      </div>
+    </div>
+  );
+};
+
+export default GroupPage;
+
+let styleContainer = css``;
+
+let styleWideColor = css`
+  background-color: #eee;
+  height: 40px;
+  width: 600px;
+  max-width: 100%;
+`;
+
+let styleFormArea = css`
+  width: 480px;
+  height: 660px;
+  border: 1px solid #ccc;
+`;

--- a/example/models/router-rules.ts
+++ b/example/models/router-rules.ts
@@ -18,5 +18,6 @@ export const routerRules: IRouteRule[] = [
   { path: "switch" },
   { path: "inline-form" },
   { path: "blank-label" },
+  { path: "group" },
   { path: "", name: "home" },
 ];

--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -19,6 +19,7 @@ import InlineFormPage from "forms/inline-form";
 import FormBlankLabel from "forms/blank-label";
 import DrawerPage from "forms/drawer";
 import CustomMultiplePage from "forms/custom-multiple";
+import GroupPage from "forms/group";
 
 let pages: { title: string; path: string }[] = [
   {
@@ -81,6 +82,10 @@ let pages: { title: string; path: string }[] = [
     title: "Blank label",
     path: genRouter.blankLabel.name,
   },
+  {
+    title: "Group",
+    path: genRouter.group.name,
+  },
 ];
 
 let Container: SFC<{ router: IRouteParseResult }> = (props) => {
@@ -116,6 +121,8 @@ let Container: SFC<{ router: IRouteParseResult }> = (props) => {
         return <InlineFormPage />;
       case genRouter.blankLabel.name:
         return <FormBlankLabel />;
+      case genRouter.group.name:
+        return <GroupPage />;
       default:
         return <FormBasic />;
     }

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -156,14 +156,16 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
         );
       case EMesonFieldType.Switch:
         return (
-          <Switch
-            checked={form[item.name]}
-            className={styleSwitch}
-            disabled={item.disabled}
-            onChange={(value) => {
-              updateItem(value, item);
-            }}
-          />
+          <div>
+            <Switch
+              checked={form[item.name]}
+              className={styleSwitch}
+              disabled={item.disabled}
+              onChange={(value) => {
+                updateItem(value, item);
+              }}
+            />
+          </div>
         );
       case EMesonFieldType.Select:
         let currentValue = form[item.name];
@@ -203,7 +205,7 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
             })}
           </Select>
         );
-      case EMesonFieldType.Group:
+      case EMesonFieldType.Nested:
         return renderItems(item.children);
       case EMesonFieldType.Custom:
       // already handled outside
@@ -217,7 +219,7 @@ export let ForwardForm: React.RefForwardingComponent<MesonFormHandler, MesonForm
         return null;
       }
 
-      if (item.type === EMesonFieldType.Fragment) {
+      if (item.type === EMesonFieldType.Group) {
         return <>{renderItems(item.children)}</>;
       }
 

--- a/src/inline-form.tsx
+++ b/src/inline-form.tsx
@@ -117,11 +117,11 @@ let MesonInlineForm: FC<{
   return (
     <div className={cx(row, styleContainer)}>
       {props.items.map((item, idx) => {
-        if (item.type === EMesonFieldType.Fragment) {
+        if (item.type === EMesonFieldType.Group) {
           return <>{item.children.map(renderItem)}</>;
         }
 
-        if (item.type === EMesonFieldType.Group) {
+        if (item.type === EMesonFieldType.Nested) {
           return `Not supported type: ${item.type}`;
         }
 

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -29,10 +29,10 @@ export enum EMesonFieldType {
   Select = "select",
   Custom = "custom",
   CustomMultiple = "custom-multiple",
-  Group = "group",
+  Nested = "nested",
   Switch = "switch",
   // like React fragment
-  Fragment = "fragment",
+  Group = "group",
 }
 
 export interface IMesonFieldBaseProps<K = string> {
@@ -127,15 +127,15 @@ export interface IMesonFieldCustomMultiple<K = string> extends IMesonFieldBasePr
   validateMultiple: (form: any, item: IMesonFieldCustomMultiple<K>) => IMesonErrors;
 }
 
-export interface IMesonGroupField extends IMesonFieldBaseProps {
-  type: EMesonFieldType.Group;
-  children: IMesonFieldItem[];
+export interface IMesonFieldNested<K> extends IMesonFieldBaseProps {
+  type: EMesonFieldType.Nested;
+  children: IMesonFieldItem<K>[];
 }
 
-export interface IMesonFieldsFragment {
-  type: EMesonFieldType.Fragment;
+export interface IMesonFieldsGroup<K> {
+  type: EMesonFieldType.Group;
   shouldHide?: (form: any) => boolean;
-  children: IMesonFieldItem[];
+  children: IMesonFieldItem<K>[];
 }
 
 export type IMesonFieldItemHasValue<K = string> =
@@ -151,6 +151,6 @@ export type IMesonFieldItem<K = string> =
   | IMesonSelectField<K>
   | IMesonCustomField<K>
   | IMesonSwitchField<K>
-  | IMesonGroupField
-  | IMesonFieldsFragment
+  | IMesonFieldNested<K>
+  | IMesonFieldsGroup<K>
   | IMesonFieldCustomMultiple<K>;

--- a/src/util/render.ts
+++ b/src/util/render.ts
@@ -9,8 +9,8 @@ export let traverseItems = (xs: IMesonFieldItem[], form: ISimpleObject, method: 
     switch (x.type) {
       case EMesonFieldType.CustomMultiple:
         return;
+      case EMesonFieldType.Nested:
       case EMesonFieldType.Group:
-      case EMesonFieldType.Fragment:
         traverseItems(x.children, form, method);
       default:
         method(x);
@@ -27,8 +27,8 @@ export let traverseItemsReachCustomMultiple = (xs: IMesonFieldItem[], form: ISim
       case EMesonFieldType.CustomMultiple:
         method(x);
         return;
+      case EMesonFieldType.Nested:
       case EMesonFieldType.Group:
-      case EMesonFieldType.Fragment:
         traverseItemsReachCustomMultiple(x.children, form, method);
       default:
         return;


### PR DESCRIPTION
After this change:

* `Nested`, fields that nested after this field.
* `Group`, not nested, but multiple fields, designed for show/hiding multiple fields with one variable.

This is a breaking change. However it’s probably not in use yet.
