### PR TITLE
drawer标题居中

### DIFF
--- a/src/component/drawer.tsx
+++ b/src/component/drawer.tsx
@@ -55,9 +55,10 @@ export default class MesonDrawer extends React.Component<IProps, any> {
           <div className={styleBackdrop} onClick={this.props.onClose}>
             <div className={cx(column, stylePopPage, "drawer-card")} style={{ width: this.props.width }} onClick={this.onContainerClick}>
               <div className={cx(rowParted, styleHeader, this.props.headerClassName)}>
+                <span />
                 {this.props.title}
 
-                {this.props.hideClose ? null : <JimoIcon name={EJimoIcon.slimCross} className={styleIcon} onClick={this.props.onClose} />}
+                {this.props.hideClose ? <span /> : <JimoIcon name={EJimoIcon.slimCross} className={styleIcon} onClick={this.props.onClose} />}
               </div>
               {this.props.renderContent()}
             </div>


### PR DESCRIPTION
直接用center的话，关闭icon也会一起居中...
所以加了个span空元素，然后还是沿用原来的space-between