### PR TITLE
完善 `meson-core` 类型

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.2.11",
+  "version": "0.2.12-a1",
   "description": "",
   "main": "./lib/form.js",
   "types": "./lib/form.d.ts",
@@ -67,9 +67,9 @@
     "webpack-hud": "^0.1.2"
   },
   "peerDependencies": {
+    "@jimengio/dropdown": "*",
     "@jimengio/fa-icons": "*",
     "@jimengio/jimo-icons": "*",
-    "@jimengio/dropdown": "*",
     "@jimengio/safe-property": "*",
     "@jimengio/shared-utils": "*",
     "antd": "^3.18.2",

--- a/src/hook/meson-core.ts
+++ b/src/hook/meson-core.ts
@@ -13,13 +13,13 @@ export let useMesonCore = <T>(props: {
   onFieldChange?: (name: string, v: any, prevForm?: T, modifyForm?: FuncMesonModifyForm<T>) => void;
   submitOnEdit?: boolean;
 }) => {
-  let [form, updateForm] = useImmer(props.initialValue as T);
-  let [errors, updateErrors] = useImmer({});
+  let [form, updateForm] = useImmer<T>(props.initialValue);
+  let [errors, updateErrors] = useImmer<IMesonErrors<T>>({});
   let modifiedState = useRef(false);
 
   let onCheckSubmitWithValue = (passedForm?: T) => {
     let latestForm = passedForm;
-    let currentErrors = {} as IMesonErrors<T>;
+    let currentErrors: IMesonErrors<T> = {};
     let hasErrors = false;
 
     traverseItems(props.items, latestForm, (item: IMesonFieldItemHasValue) => {
@@ -40,14 +40,14 @@ export let useMesonCore = <T>(props: {
       }
     });
 
-    updateErrors((draft: IMesonErrors<T>) => {
+    updateErrors((draft) => {
       return currentErrors;
     });
 
     if (!hasErrors) {
       props.onSubmit(latestForm, (serverErrors) => {
         // errors from server not in use yet
-        updateErrors((draft: IMesonErrors<T>) => {
+        updateErrors((draft) => {
           return serverErrors;
         });
       });
@@ -55,7 +55,7 @@ export let useMesonCore = <T>(props: {
     }
   };
 
-  let checkItemWithValue = (x: any, item: IMesonFieldItemHasValue) => {
+  let checkItemWithValue = (x: any, item: IMesonFieldItemHasValue<T>) => {
     if (props.submitOnEdit) {
       let newForm = produce(form, (draft) => {
         draft[item.name] = x;
@@ -81,7 +81,7 @@ export let useMesonCore = <T>(props: {
     }
 
     let results = item.validateMultiple ? item.validateMultiple(newForm, item) : {};
-    updateErrors((draft: T) => {
+    updateErrors((draft) => {
       // reset errors of related fields first
       item.names.forEach((name) => {
         draft[name as string] = null;
@@ -90,8 +90,8 @@ export let useMesonCore = <T>(props: {
     });
   };
 
-  let updateItem = (x: any, item: IMesonFieldItemHasValue) => {
-    updateForm((draft: Draft<T>) => {
+  let updateItem = (x: any, item: IMesonFieldItemHasValue<T>) => {
+    updateForm((draft) => {
       draft[item.name] = x;
     });
     modifiedState.current = true;
@@ -113,7 +113,7 @@ export let useMesonCore = <T>(props: {
       onCheckSubmitWithValue(form);
     },
     onCheckSubmitWithValue,
-    checkItem: (item: IMesonFieldItemHasValue) => {
+    checkItem: (item: IMesonFieldItemHasValue<T>) => {
       checkItemWithValue(form[item.name], item);
     },
     checkItemCustomMultiple,


### PR DESCRIPTION
1. 修复 `checkItem` 泛型丢失；
2. 完善 `form` `error` (immer data) 类型申明，去除多余重复申明。