### PR TITLE
add valueContainerClassName; alpha release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.3.2-a1",
+  "version": "0.3.2-a2",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -159,7 +159,9 @@ export function useMesonItems<T = IMesonFormBase>(props: MesonFormProps<T>): [Re
         key,
         item as any,
         error,
-        <ValueFieldContainer fullWidth={fullWidth}>{renderValueItem(item)}</ValueFieldContainer>,
+        <ValueFieldContainer fullWidth={fullWidth} className={item.valueContainerClassName}>
+          {renderValueItem(item)}
+        </ValueFieldContainer>,
         props.labelClassName,
         props.errorClassName,
         hideLabel,

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -74,6 +74,8 @@ export interface IMesonInputField<T> extends IMesonFieldBaseProps<T> {
    * by default validation performs after each blur event
    */
   checkOnChange?: boolean;
+  /** add styles to container of value, which is inside each field and around the value */
+  valueContainerClassName?: string;
 }
 
 export interface IMesonNumberField<T> extends IMesonFieldBaseProps<T> {
@@ -86,6 +88,7 @@ export interface IMesonNumberField<T> extends IMesonFieldBaseProps<T> {
   min?: number;
   max?: number;
   inputProps?: InputNumberProps;
+  valueContainerClassName?: string;
 }
 
 export interface IMesonSwitchField<T> extends IMesonFieldBaseProps<T> {
@@ -94,6 +97,7 @@ export interface IMesonSwitchField<T> extends IMesonFieldBaseProps<T> {
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
   validator?: FuncMesonValidator<T>;
+  valueContainerClassName?: string;
 }
 
 export interface IMesonSelectItem {
@@ -113,6 +117,7 @@ export interface IMesonSelectField<T> extends IMesonFieldBaseProps<T> {
   translateNonStringvalue?: boolean;
   allowClear?: boolean;
   selectProps?: SelectProps;
+  valueContainerClassName?: string;
 }
 
 export interface IMesonCustomField<T> extends IMesonFieldBaseProps<T> {


### PR DESCRIPTION
`ValueFieldContainer` 组件的默认样式是 180px 宽度, 而且不能更改. 这个会影响到具体使用. 直接增加一个 className 用于修改.

由于不是常用的配置, 而且不同的类型可能有不同的样式需求, 所以不在 Form 组件上直接加共享的 `valueContainerClassName`. 可能出现的情况是某个特殊场景, 很多个 item 都要各自加一遍样式, 目前认为可以接受.
 
名称略长... 但没想到更好的.