### PR TITLE
api: expose updateForm at useFormItems; alpha release

### DIFF
--- a/example/forms/use-items.tsx
+++ b/example/forms/use-items.tsx
@@ -6,6 +6,7 @@ import { row, Space } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocBlock, DocSnippet } from "@jimengio/doc-frame";
 import { getLink } from "util/link";
+import { JimoButton } from "@jimengio/jimo-basics";
 
 let selectItems: IMesonSelectItem[] = [
   {
@@ -87,6 +88,8 @@ let FormUseItems: FC<{}> = (props) => {
     },
   });
 
+  let { updateForm } = formInternals;
+
   return (
     <div className={cx(styleContainer)}>
       <DocBlock content={intro}></DocBlock>
@@ -95,7 +98,16 @@ let FormUseItems: FC<{}> = (props) => {
         <div style={{ padding: 16 }}>
           Custom UI
           <Space width={16} />
-          <button onClick={onCheckSubmit}>onSubmit</button>
+          <JimoButton
+            onClick={() => {
+              updateForm((draft) => {
+                draft.name = "JIMENGIO";
+              });
+            }}
+            text="Reset name"
+          />
+          <Space width={16} />
+          <JimoButton fillColor onClick={onCheckSubmit} text="onSubmit" />
         </div>
 
         <div className={styleData}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.3.3-a3",
+  "version": "0.3.3-a4",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.3.3-a2",
+  "version": "0.3.3-a3",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -46,7 +46,9 @@ export interface MesonFormProps<T> {
 }
 
 /** Hooks API for customizing UIs */
-export function useMesonItems<T = IMesonFormBase>(props: MesonFormProps<T>): [ReactNode, () => void, { formData: T }] {
+export function useMesonItems<T = IMesonFormBase>(
+  props: MesonFormProps<T>
+): [ReactNode, () => void, { formData: T; updateForm: (f: (draft: Draft<T>) => void | T) => void }] {
   let {
     formAny: form,
     updateForm,
@@ -182,7 +184,11 @@ export function useMesonItems<T = IMesonFormBase>(props: MesonFormProps<T>): [Re
     });
   };
 
-  return [<div className={cx(flex, styleItemsContainer, props.itemsClassName)}>{renderItems(props.items)}</div>, onCheckSubmit, { formData: form }];
+  return [
+    <div className={cx(flex, styleItemsContainer, props.itemsClassName)}>{renderItems(props.items)}</div>,
+    onCheckSubmit,
+    { formData: form, updateForm: updateForm },
+  ];
 }
 
 /** Main form component for Meson

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { MesonFormProps, MesonForm, MesonFormModal, MesonFormDrawer, MesonFormDropdown } from "./form";
+export { MesonFormProps, MesonForm, MesonFormModal, MesonFormDrawer, MesonFormDropdown, useMesonItems } from "./form";
 
 export { MesonFormForwarded } from "./form-forwarded";
 export { IMesonFieldItem, EMesonFieldType, IMesonSelectItem } from "./model/types";


### PR DESCRIPTION
涉及到 transition 的问题, 做过渡动画需要 formModal 提前挂载, 提前挂载的话, 内部状态需要更新, 这样就需要通过 `updateForm` 来操作了, 所以故意暴露到外面.

参考 http://fe.jimu.io/meson-form/#/use-items 当中的 "Reset name" 按钮.
