### PR TITLE
add onSubmit options on onCheckSubmit method; alpha release

### DIFF
--- a/example/forms/use-items.tsx
+++ b/example/forms/use-items.tsx
@@ -66,6 +66,25 @@ let codeUse = `
 </div>
 `;
 
+let codeCallback = `
+let [formElements, onCheckSubmit, formInternals] = useMesonItems({
+  initialValue: {},
+  items: formItems,
+  onSubmit: null,
+});
+
+onCheckSubmit({
+  onSubmit: (form) => {
+    console.log("submit when valid", form);
+  },
+});
+`;
+
+let contentCallback = `
+\`onCheckSubmit\` 有一个比较特殊的用法, 可以在参数当中传入 \`onSubmit\`, 校验通过时会调用这个 \`onSubmit\`.
+这样也就可以替代 props 当中的 \`onSubmit\` 使用, 而 props 当中就需要强行把 \`onSubmit\` 设置为 null 了.
+`;
+
 let FormUseItems: FC<{}> = (props) => {
   let [form, setForm] = useState({});
 
@@ -94,7 +113,17 @@ let FormUseItems: FC<{}> = (props) => {
             text="Reset name"
           />
           <Space width={16} />
-          <JimoButton fillColor onClick={onCheckSubmit} text="onSubmit" />
+          <JimoButton
+            fillColor
+            onClick={() => {
+              onCheckSubmit({
+                onSubmit: (form) => {
+                  console.log("when valid", form);
+                },
+              });
+            }}
+            text="onSubmit"
+          />
         </div>
 
         <div className={styleData}>
@@ -108,6 +137,11 @@ let FormUseItems: FC<{}> = (props) => {
         <DocBlock content={contentInternals} />
 
         <DocSnippet code={codeUse} />
+      </DocDemo>
+
+      <DocDemo title="Callback syntax">
+        <DocBlock content={contentCallback} />
+        <DocSnippet code={codeCallback} />
       </DocDemo>
     </div>
   );

--- a/example/forms/wrap-meson-core.tsx
+++ b/example/forms/wrap-meson-core.tsx
@@ -90,7 +90,13 @@ let WrapMesonCore: FC<{}> = (props) => {
             }
           })}
           <div>
-            <button onClick={onCheckSubmit}>Submit</button>
+            <button
+              onClick={() => {
+                onCheckSubmit();
+              }}
+            >
+              Submit
+            </button>
           </div>
         </div>
       </DocDemo>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.3.3",
+  "version": "0.3.4-a1",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.3.4-a1",
+  "version": "0.3.4-a2",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -27,6 +27,7 @@ import { createItemKey } from "./util/string";
 export interface MesonFormProps<T> {
   initialValue: T;
   items: IMesonFieldItem<T>[];
+  /** when set onSubmit:null on useFormItems, make sure {onSubmit: f} is passed to onCheckSubmit */
   onSubmit: (form: T, onServerErrors?: (x: IMesonErrors<T>) => void) => void;
   onReset?: () => void;
   onCancel?: () => void;

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -46,9 +46,7 @@ export interface MesonFormProps<T> {
 }
 
 /** Hooks API for customizing UIs */
-export function useMesonItems<T = IMesonFormBase>(
-  props: MesonFormProps<T>
-): [ReactNode, () => void, { formData: T; updateForm: (f: (draft: Draft<T>) => void | T) => void }] {
+export function useMesonItems<T = IMesonFormBase>(props: MesonFormProps<T>) {
   let {
     formAny: form,
     updateForm,
@@ -184,11 +182,11 @@ export function useMesonItems<T = IMesonFormBase>(
     });
   };
 
-  return [
-    <div className={cx(flex, styleItemsContainer, props.itemsClassName)}>{renderItems(props.items)}</div>,
-    onCheckSubmit,
-    { formData: form, updateForm: updateForm },
-  ];
+  let ui = <div className={cx(flex, styleItemsContainer, props.itemsClassName)}>{renderItems(props.items)}</div>;
+
+  let formInternals = { formData: form, updateForm: updateForm };
+
+  return [ui, onCheckSubmit, formInternals] as [ReactNode, typeof onCheckSubmit, typeof formInternals];
 }
 
 /** Main form component for Meson


### PR DESCRIPTION
`useFormItems` 写法中, 允许 `onCheckSubmit` 传入一个 `{onSubmit: (form) => { ... }}` 参数, 在校验通过的情况下直接调用方法处理数据. 原来的 `onSubmit` 是在 `useFormItems({..., onSubmit: (form) => { ... }})` 当中写的.

目前只是作为一个探索性的写法, 逻辑可能会更清晰一点, 不确定优劣.

文档 http://fe.jimu.io/meson-form/#/use-items .
