### PR TITLE
refactor: split out textarea type; alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Define forms in an array with mostly JSON(with functions and enumerables):
 ```tsx
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "name",
     label: "名字",
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     shouldHide: (form) => {
       return form.amount && form.amount > 6;
     },
@@ -125,7 +125,7 @@ Props for `MesonFormDrawer` and `MesonFormDropdown` are almost same to `MesonFor
 
 ```ts
 {
-  type: EMesonFieldType.Custom,
+  type: 'custom',
   name: "size",
   label: "自定义",
   render: (value, onChange, form, onCheck) => {

--- a/example/forms/auto-save.tsx
+++ b/example/forms/auto-save.tsx
@@ -2,24 +2,24 @@ import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { row } from "@jimengio/shared-utils";
 import { MesonForm } from "meson-form";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem } from "../../src/model/types";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocSnippet, DocBlock } from "@jimengio/doc-frame";
 import { getLink } from "util/link";
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "name",
     label: "名字",
   },
   {
-    type: EMesonFieldType.Switch,
+    type: "switch",
     name: "switch",
     label: "开关",
   },
   {
-    type: EMesonFieldType.Select,
+    type: "select",
     name: "select",
     label: "选择",
     options: [

--- a/example/forms/basic.tsx
+++ b/example/forms/basic.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "../../src/form";
-import { IMesonFieldItem, EMesonFieldType, IMesonSelectItem } from "../../src/model/types";
+import { IMesonFieldItem, IMesonSelectItem } from "../../src/model/types";
 import { row } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocBlock, DocSnippet } from "@jimengio/doc-frame";
@@ -14,7 +14,7 @@ Meson Form 基本的用法是用 JSON 结构的数据定义规则, 然后交给 
 `;
 
 let code = `
-import { MesonForm, IMesonFieldItem, EMesonFieldType } from "@jimengio/meson-form";
+import { MesonForm, IMesonFieldItem } from "@jimengio/meson-form";
 
 let selectItems: IMesonSelectItem[] = [
   {
@@ -29,13 +29,13 @@ let selectItems: IMesonSelectItem[] = [
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Input,
+    type: 'input',
     name: "name",
     label: "名字",
     required: true,
   },
   {
-    type: EMesonFieldType.Select,
+    type: 'select',
     name: "city",
     options: selectItems,
     label: "城市",
@@ -67,13 +67,13 @@ let selectItems: IMesonSelectItem[] = [
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "name",
     label: "名字",
     required: true,
   },
   {
-    type: EMesonFieldType.Select,
+    type: "select",
     name: "city",
     options: selectItems,
     label: "城市",

--- a/example/forms/blank-label.tsx
+++ b/example/forms/blank-label.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "../../src/form";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem } from "../../src/model/types";
 import { row } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocBlock } from "@jimengio/doc-frame";
@@ -9,19 +9,19 @@ import { getLink } from "util/link";
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "name",
     placeholder: "Add name",
     label: null,
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "address",
     placeholder: "Add address",
     label: null,
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "note",
     placeholder: "Add note",
     label: "Some note",

--- a/example/forms/custom-multiple.tsx
+++ b/example/forms/custom-multiple.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "../../src/form";
-import { IMesonFieldItem, EMesonFieldType, FuncMesonModifyForm, IMesonErrors } from "../../src/model/types";
+import { IMesonFieldItem, FuncMesonModifyForm, IMesonErrors } from "../../src/model/types";
 import { row } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import Input from "antd/lib/input";
@@ -16,13 +16,13 @@ interface IDemo {
 
 let formItems: IMesonFieldItem<IDemo>[] = [
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     label: "simple",
     name: "a0",
     required: true,
   },
   {
-    type: EMesonFieldType.CustomMultiple,
+    type: "custom-multiple",
     names: ["a", "b"],
     label: "自定义",
     required: true,
@@ -108,13 +108,13 @@ let codeCustomMultiple = `
 
 let formItems: IMesonFieldItem<IDemo>[] = [
   {
-    type: EMesonFieldType.Input,
+    type: 'input',
     label: "simple",
     name: "a0",
     required: true,
   },
   {
-    type: EMesonFieldType.CustomMultiple,
+    type: 'custom-multiple',
     names: ["a", "b"],
     label: "自定义",
     required: true,

--- a/example/forms/custom.tsx
+++ b/example/forms/custom.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "../../src/form";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem } from "../../src/model/types";
 import { row } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import Input from "antd/lib/input";
@@ -10,7 +10,7 @@ import { getLink } from "util/link";
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Custom,
+    type: "custom",
     name: "x",
     label: "自定义",
     render: (value, onChange, form, onCheck) => {
@@ -64,7 +64,7 @@ let styleContainer = css``;
 let codeCustom = `
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Custom,
+    type: 'custom',
     name: "x",
     label: "自定义",
     render: (value, onChange, form, onCheck) => {

--- a/example/forms/decorative.tsx
+++ b/example/forms/decorative.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "../../src/form";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem } from "../../src/model/types";
 import { row } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocSnippet, DocBlock } from "@jimengio/doc-frame";
@@ -9,30 +9,30 @@ import { getLink } from "util/link";
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Decorative,
+    type: "decorative",
     render: () => <h1>From</h1>,
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "name",
     label: "名字",
   },
   {
-    type: EMesonFieldType.Decorative,
+    type: "decorative",
     render: (form) => <span>hello {form.name}</span>,
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "address",
     label: "地址",
   },
   {
-    type: EMesonFieldType.Switch,
+    type: "switch",
     name: "switch",
     label: "switch",
   },
   {
-    type: EMesonFieldType.Decorative,
+    type: "decorative",
     render: (form) => <span>shouldHide</span>,
     shouldHide: (form) => form.switch,
   },
@@ -68,12 +68,12 @@ let styleContainer = css``;
 
 let codeDecorative = `
 {
-  type: EMesonFieldType.Decorative,
+  type: 'decorative',
   render: (form) => <span>hello {form.name}</span>,
 },
 
 {
-  type: EMesonFieldType.Decorative,
+  type: 'decorative',
   render: (form) => <span>shouldHide</span>,
   shouldHide: (form) => form.switch,
 },

--- a/example/forms/draft.tsx
+++ b/example/forms/draft.tsx
@@ -78,8 +78,7 @@ let formItems: IMesonFieldItem<IDemo>[] = [
     required: true,
   },
   {
-    type: EMesonFieldType.Input,
-    textarea: true,
+    type: EMesonFieldType.Textarea,
     label: "描述",
     name: "description",
     required: true,
@@ -89,8 +88,7 @@ let formItems: IMesonFieldItem<IDemo>[] = [
     shouldHide: () => true,
     children: [
       {
-        type: EMesonFieldType.Input,
-        textarea: true,
+        type: EMesonFieldType.Textarea,
         label: "描述",
         name: "description",
         required: true,

--- a/example/forms/draft.tsx
+++ b/example/forms/draft.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "meson-form";
 import { EMesonFooterLayout } from "../../src/component/form-footer";
-import { IMesonSelectItem, IMesonFieldItem, EMesonFieldType, EMesonValidate } from "../../src/model/types";
+import { IMesonSelectItem, IMesonFieldItem, EMesonValidate } from "../../src/model/types";
 import Input from "antd/lib/input";
 import { row } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
@@ -33,7 +33,7 @@ let options: IMesonSelectItem[] = [
 
 let formItems: IMesonFieldItem<IDemo>[] = [
   {
-    type: EMesonFieldType.Select,
+    type: "select",
     label: "物料",
     name: "material",
     required: true,
@@ -48,7 +48,7 @@ let formItems: IMesonFieldItem<IDemo>[] = [
     },
   },
   {
-    type: EMesonFieldType.Number,
+    type: "number",
     label: "数量",
     name: "amount",
     required: true,
@@ -62,14 +62,14 @@ let formItems: IMesonFieldItem<IDemo>[] = [
     },
   },
   {
-    type: EMesonFieldType.Number,
+    type: "number",
     label: "计数",
     name: "count",
     required: true,
     validateMethods: [EMesonValidate.Number],
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     shouldHide: (form) => {
       return form.amount && form.amount > 6;
     },
@@ -78,17 +78,17 @@ let formItems: IMesonFieldItem<IDemo>[] = [
     required: true,
   },
   {
-    type: EMesonFieldType.Textarea,
+    type: "textarea",
     label: "描述",
     name: "description",
     required: true,
   },
   {
-    type: EMesonFieldType.Group,
+    type: "group",
     shouldHide: () => true,
     children: [
       {
-        type: EMesonFieldType.Textarea,
+        type: "textarea",
         label: "描述",
         name: "description",
         required: true,
@@ -96,7 +96,7 @@ let formItems: IMesonFieldItem<IDemo>[] = [
     ],
   },
   {
-    type: EMesonFieldType.Custom,
+    type: "custom",
     name: null,
     label: "Width test",
     render: (value) => {
@@ -104,12 +104,12 @@ let formItems: IMesonFieldItem<IDemo>[] = [
     },
   },
   {
-    type: EMesonFieldType.Nested,
+    type: "nested",
     label: "Nested",
-    children: [{ type: EMesonFieldType.Select, label: "物料", name: "materialInside", required: true, options: options }],
+    children: [{ type: "select", label: "物料", name: "materialInside", required: true, options: options }],
   },
   {
-    type: EMesonFieldType.Custom,
+    type: "custom",
     name: "size",
     label: "自定义",
     render: (value, onChange, form, onCheck) => {

--- a/example/forms/drawer.tsx
+++ b/example/forms/drawer.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from "react";
 import { css } from "emotion";
 import { lingual } from "../../src/lingual";
 import { MesonFormDrawer } from "meson-form";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem } from "../../src/model/types";
 import Button from "antd/lib/button";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocSnippet } from "@jimengio/doc-frame";
@@ -15,7 +15,7 @@ let DrawerPage: FC<{}> = (props) => {
 
   let formItems: IMesonFieldItem[] = [
     {
-      type: EMesonFieldType.Input,
+      type: "input",
       name: "demo",
       label: "DEMO",
     },

--- a/example/forms/dropdown.tsx
+++ b/example/forms/dropdown.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from "react";
 import { css } from "emotion";
 import { lingual } from "../../src/lingual";
 import { MesonFormDropdown } from "meson-form";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem } from "../../src/model/types";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocSnippet } from "@jimengio/doc-frame";
 import { getLink } from "util/link";
@@ -13,12 +13,12 @@ let DropdownPage: FC<{}> = (props) => {
 
   let formItems: IMesonFieldItem[] = [
     {
-      type: EMesonFieldType.Input,
+      type: "input",
       name: "demo",
       label: "DEMO",
     },
     {
-      type: EMesonFieldType.Input,
+      type: "input",
       name: "demo",
       label: "DEMO",
     },

--- a/example/forms/forward-form.tsx
+++ b/example/forms/forward-form.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonFormHandler, MesonFormForwarded } from "../../src/form-forwarded";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem } from "../../src/model/types";
 import { row, column } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import Button from "antd/lib/button";
@@ -10,7 +10,7 @@ import { getLink } from "util/link";
 
 let formItems: IMesonFieldItem<{ name?: string }>[] = [
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "name",
     label: "名字",
   },

--- a/example/forms/group.tsx
+++ b/example/forms/group.tsx
@@ -48,8 +48,7 @@ let formItems: IMesonFieldItem<IDemo>[] = [
         required: true,
       },
       {
-        type: EMesonFieldType.Input,
-        textarea: true,
+        type: EMesonFieldType.Textarea,
         label: "b",
         name: "b",
         required: true,
@@ -75,8 +74,7 @@ let formItems: IMesonFieldItem<IDemo>[] = [
         name: "e",
       },
       {
-        type: EMesonFieldType.Input,
-        textarea: true,
+        type: EMesonFieldType.Textarea,
         label: "f",
         name: "f",
       },

--- a/example/forms/group.tsx
+++ b/example/forms/group.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "meson-form";
 import { EMesonFooterLayout } from "../../src/component/form-footer";
-import { IMesonSelectItem, IMesonFieldItem, EMesonFieldType, EMesonValidate } from "../../src/model/types";
+import { IMesonSelectItem, IMesonFieldItem, EMesonValidate } from "../../src/model/types";
 import Input from "antd/lib/input";
 import { row, expand } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
@@ -33,22 +33,22 @@ let options: IMesonSelectItem[] = [
 
 let formItems: IMesonFieldItem<IDemo>[] = [
   {
-    type: EMesonFieldType.Switch,
+    type: "switch",
     label: "Show/hide",
     name: "visibility",
   },
   {
-    type: EMesonFieldType.Group,
+    type: "group",
     shouldHide: (form) => form.visibility,
     children: [
       {
-        type: EMesonFieldType.Input,
+        type: "input",
         label: "a",
         name: "a",
         required: true,
       },
       {
-        type: EMesonFieldType.Textarea,
+        type: "textarea",
         label: "b",
         name: "b",
         required: true,
@@ -57,24 +57,24 @@ let formItems: IMesonFieldItem<IDemo>[] = [
     ],
   },
   {
-    type: EMesonFieldType.Nested,
+    type: "nested",
     label: "Nested",
     children: [
-      { type: EMesonFieldType.Select, label: "物料", name: "c", required: true, options: options },
-      { type: EMesonFieldType.Input, label: "d", name: "d" },
+      { type: "select", label: "物料", name: "c", required: true, options: options },
+      { type: "input", label: "d", name: "d" },
     ],
   },
   {
-    type: EMesonFieldType.Group,
+    type: "group",
     horizontal: true,
     children: [
       {
-        type: EMesonFieldType.Input,
+        type: "input",
         label: "e",
         name: "e",
       },
       {
-        type: EMesonFieldType.Textarea,
+        type: "textarea",
         label: "f",
         name: "f",
       },
@@ -84,52 +84,52 @@ let formItems: IMesonFieldItem<IDemo>[] = [
 
 let formItems2: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Decorative,
+    type: "decorative",
     render: () => <h2>Group 01 (width: 200px)</h2>,
   },
   {
-    type: EMesonFieldType.Group,
+    type: "group",
     horizontal: true,
     itemWidth: 200,
     children: [
       {
-        type: EMesonFieldType.Input,
+        type: "input",
         label: "1-1",
         name: "1-1",
       },
       {
-        type: EMesonFieldType.Input,
+        type: "input",
         label: "1-2",
         name: "1-2",
       },
       {
-        type: EMesonFieldType.Input,
+        type: "input",
         label: "1-3",
         name: "1-3",
       },
       {
-        type: EMesonFieldType.Input,
+        type: "input",
         label: "1-4",
         name: "1-4",
       },
     ],
   },
   {
-    type: EMesonFieldType.Decorative,
+    type: "decorative",
     render: () => <h2>Group 02 (width: 50%)</h2>,
   },
   {
-    type: EMesonFieldType.Group,
+    type: "group",
     horizontal: true,
     itemWidth: "50%",
     children: [
       {
-        type: EMesonFieldType.Input,
+        type: "input",
         label: "2-1",
         name: "2-1",
       },
       {
-        type: EMesonFieldType.Input,
+        type: "input",
         label: "2-2",
         name: "2-2",
       },

--- a/example/forms/inline-form.tsx
+++ b/example/forms/inline-form.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem } from "../../src/model/types";
 import { row } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import MesonInlineForm from "../../src/inline-form";
@@ -9,24 +9,24 @@ import { getLink } from "util/link";
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "name",
     label: "Name",
     required: true,
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "address",
     label: "Address",
   },
   {
-    type: EMesonFieldType.Select,
+    type: "select",
     name: "area",
     label: "Area",
     options: [],
   },
   {
-    type: EMesonFieldType.Custom,
+    type: "custom",
     name: "description",
     label: "Description",
     render: (x, onChange) => {

--- a/example/forms/login-validations.tsx
+++ b/example/forms/login-validations.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "../../src/form";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem } from "../../src/model/types";
 import { row } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocBlock, DocSnippet } from "@jimengio/doc-frame";
@@ -14,7 +14,7 @@ interface IGuest {
 
 let formItems: IMesonFieldItem<IGuest>[] = [
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "phone",
     label: "手机号",
     fullWidth: true,
@@ -31,7 +31,7 @@ let formItems: IMesonFieldItem<IGuest>[] = [
     },
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "password",
     label: "密码",
     fullWidth: true,
@@ -40,7 +40,7 @@ let formItems: IMesonFieldItem<IGuest>[] = [
     },
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "confirm",
     label: "重复密码",
     fullWidth: true,
@@ -93,7 +93,7 @@ let styleForm = css`
 
 let codeCheckChange = `
 {
-  type: EMesonFieldType.Input,
+  type: 'input',
   name: "phone",
   label: "手机号",
   fullWidth: true,

--- a/example/forms/modal.tsx
+++ b/example/forms/modal.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from "react";
 import { css } from "emotion";
 import { lingual } from "../../src/lingual";
 import { MesonFormModal } from "meson-form";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem } from "../../src/model/types";
 import { JimoButton } from "@jimengio/jimo-basics";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocSnippet, DocBlock } from "@jimengio/doc-frame";
@@ -46,32 +46,32 @@ let ModalPage: FC<{}> = (props) => {
 
   let formItems: IMesonFieldItem[] = [
     {
-      type: EMesonFieldType.Input,
+      type: "input",
       name: "demo",
       label: "DEMO",
     },
     {
-      type: EMesonFieldType.Input,
+      type: "input",
       name: "demo",
       label: "DEMO",
     },
     {
-      type: EMesonFieldType.Input,
+      type: "input",
       name: "demo",
       label: "DEMO",
     },
     {
-      type: EMesonFieldType.Input,
+      type: "input",
       name: "demo",
       label: "DEMO",
     },
     {
-      type: EMesonFieldType.Input,
+      type: "input",
       name: "demo",
       label: "DEMO----------------------test length",
     },
     {
-      type: EMesonFieldType.Number,
+      type: "number",
       name: "numberdemo",
       label: "number DEMO",
       inputProps: {

--- a/example/forms/modify-on-change.tsx
+++ b/example/forms/modify-on-change.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "../../src/form";
-import { IMesonFieldItem, EMesonFieldType, IMesonSelectItem, FuncMesonModifyForm } from "../../src/model/types";
+import { IMesonFieldItem, IMesonSelectItem, FuncMesonModifyForm } from "../../src/model/types";
 import { row, xHiddenYAuto } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocSnippet, DocBlock } from "@jimengio/doc-frame";
@@ -15,7 +15,7 @@ let candidates: IMesonSelectItem[] = [
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Select,
+    type: 'select',
     name: "kind",
     label: "种类",
     options: candidates,
@@ -33,13 +33,13 @@ let formItems: IMesonFieldItem[] = [
     },
   },
   {
-    type: EMesonFieldType.Input,
+    type: 'input',
     name: "place",
     label: "籍贯",
     required: true,
   },
   {
-    type: EMesonFieldType.Input,
+    type: 'input',
     name: "note",
     label: "备注",
     required: false,
@@ -70,7 +70,7 @@ interface IHome {
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Select,
+    type: "select",
     name: "kind",
     label: "种类",
     options: candidates,
@@ -88,13 +88,13 @@ let formItems: IMesonFieldItem[] = [
     },
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "place",
     label: "籍贯",
     required: true,
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "note",
     label: "备注",
     required: false,

--- a/example/forms/no-label.tsx
+++ b/example/forms/no-label.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "../../src/form";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem } from "../../src/model/types";
 import { row } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocSnippet, DocBlock } from "@jimengio/doc-frame";
@@ -9,23 +9,23 @@ import { getLink } from "util/link";
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "name",
     label: "Name",
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "address",
     label: "Address",
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "hideLabel1",
     label: "hideLabel(false)",
     hideLabel: false,
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "hideLabel2",
     label: "hideLabel(true)",
     hideLabel: true,
@@ -34,14 +34,14 @@ let formItems: IMesonFieldItem[] = [
 
 let formItems2: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "username",
     placeholder: "* username",
     label: "username",
     required: true,
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "password",
     label: "password",
     placeholder: "* password",
@@ -99,7 +99,7 @@ let styleContainer = css``;
 
 let codeHideLabel = `
 {
-  type: EMesonFieldType.Input,
+  type: 'input',
   name: "hideLabel1",
   label: "hideLabel(false)",
   hideLabel: false,

--- a/example/forms/radio.tsx
+++ b/example/forms/radio.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "../../src/form";
-import { IMesonFieldItem, EMesonFieldType, IMesonRadioItem } from "../../src/model/types";
+import { IMesonFieldItem, IMesonRadioItem } from "../../src/model/types";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocSnippet, DocBlock } from "@jimengio/doc-frame";
 import { getLink } from "util/link";
@@ -13,13 +13,13 @@ const options: IMesonRadioItem[] = [
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Radio,
+    type: "radio",
     name: "name",
     label: "name",
     options: options,
   },
   {
-    type: EMesonFieldType.Radio,
+    type: "radio",
     name: "secondName",
     label: "name 2",
     options: options,
@@ -64,13 +64,13 @@ const options: IMesonRadioItem[] = [
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Radio,
+    type: 'radio',
     name: "name",
     label: "name",
     options: options,
   },
   {
-    type: EMesonFieldType.Radio,
+    type: 'radio',
     name: "secondName",
     label: "name 2",
     options: options,

--- a/example/forms/select-page.tsx
+++ b/example/forms/select-page.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from "emotion";
 import React, { FC, useState } from "react";
-import { IMesonCustomField, IMesonFieldItem, IMesonSelectItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonCustomField, IMesonFieldItem, IMesonSelectItem } from "../../src/model/types";
 import { MesonForm } from "../../src/form";
 import { row } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
@@ -14,7 +14,7 @@ let booleanOptions: IMesonSelectItem[] = [
 
 let items: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Select,
+    type: "select",
     label: "BOOLEAN",
     name: "status",
     options: booleanOptions,
@@ -25,7 +25,7 @@ let items: IMesonFieldItem[] = [
 
 let itemsOfDisabled: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Select,
+    type: "select",
     label: "BOOLEAN Disabled",
     disabled: true,
     name: "status",
@@ -83,7 +83,7 @@ let booleanOptions: IMesonSelectItem[] = [
 
 let items: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Select,
+    type: 'select',
     label: "BOOLEAN",
     name: "status",
     options: booleanOptions,
@@ -104,7 +104,7 @@ let items: IMesonFieldItem[] = [
 let codeDisabled = `
 let items: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Select,
+    type: 'select',
     label: "BOOLEAN",
     name: "status",
     options: booleanOptions,

--- a/example/forms/switch.tsx
+++ b/example/forms/switch.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "../../src/form";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem } from "../../src/model/types";
 import { row } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocSnippet, DocBlock } from "@jimengio/doc-frame";
@@ -9,12 +9,12 @@ import { getLink } from "util/link";
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Switch,
+    type: "switch",
     name: "checked",
     label: "Checked",
   },
   {
-    type: EMesonFieldType.Switch,
+    type: "switch",
     name: "checked",
     label: "Check disabled",
     disabled: true,
@@ -51,12 +51,12 @@ let styleContainer = css``;
 let codeSwitch = `
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Switch,
+    type: 'switch',
     name: "checked",
     label: "Checked",
   },
   {
-    type: EMesonFieldType.Switch,
+    type: 'switch',
     name: "checked",
     label: "Check disabled",
     disabled: true,

--- a/example/forms/use-items.tsx
+++ b/example/forms/use-items.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm, useMesonItems } from "../../src/form";
-import { IMesonFieldItem, EMesonFieldType, IMesonSelectItem } from "../../src/model/types";
+import { IMesonFieldItem, IMesonSelectItem } from "../../src/model/types";
 import { row, Space } from "@jimengio/shared-utils";
 import DataPreview from "kits/data-preview";
 import { DocDemo, DocBlock, DocSnippet } from "@jimengio/doc-frame";
@@ -14,8 +14,8 @@ let selectItems: IMesonSelectItem[] = [
 ];
 
 let formItems: IMesonFieldItem[] = [
-  { type: EMesonFieldType.Input, name: "name", label: "名字", required: true },
-  { type: EMesonFieldType.Select, name: "city", options: selectItems, label: "城市", allowClear: true },
+  { type: "input", name: "name", label: "名字", required: true },
+  { type: "select", name: "city", options: selectItems, label: "城市", allowClear: true },
 ];
 
 let intro = `
@@ -32,8 +32,8 @@ let code = `
 import { useMesonItems } from "@jimengio/meson-form";
 
 let formItems: IMesonFieldItem[] = [
-  { type: EMesonFieldType.Input, name: "name", label: "名字", required: true },
-  { type: EMesonFieldType.Select, name: "city", options: selectItems, label: "城市" },
+  { type: 'input', name: "name", label: "名字", required: true },
+  { type: 'select', name: "city", options: selectItems, label: "城市" },
 ];
 
 let [formElements, onCheckSubmit, formInternals] = useMesonItems({

--- a/example/forms/validation.tsx
+++ b/example/forms/validation.tsx
@@ -85,8 +85,7 @@ let formItems: IMesonFieldItem[] = [
     },
   },
   {
-    type: EMesonFieldType.Input,
-    textarea: true,
+    type: EMesonFieldType.Textarea,
     label: "描述",
     name: "description",
     required: true,

--- a/example/forms/validation.tsx
+++ b/example/forms/validation.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "meson-form";
-import { IMesonFieldItem, EMesonFieldType } from "../../src/model/types";
+import { IMesonFieldItem } from "../../src/model/types";
 import DataPreview from "kits/data-preview";
 import { row } from "@jimengio/shared-utils";
 import Select from "antd/lib/select";
@@ -12,14 +12,14 @@ import { getLink } from "util/link";
 
 let formItems: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     required: true,
     label: "名称",
     name: "name",
   },
 
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     required: true,
     label: "名称",
     name: "longName",
@@ -30,7 +30,7 @@ let formItems: IMesonFieldItem[] = [
     },
   },
   {
-    type: EMesonFieldType.Custom,
+    type: "custom",
     label: "性别",
     name: "sex",
     /** 测试自定义layout样式 */
@@ -58,7 +58,7 @@ let formItems: IMesonFieldItem[] = [
     },
   },
   {
-    type: EMesonFieldType.Custom,
+    type: "custom",
     label: "自定义描述",
     name: "customDescription",
     required: true,
@@ -85,7 +85,7 @@ let formItems: IMesonFieldItem[] = [
     },
   },
   {
-    type: EMesonFieldType.Textarea,
+    type: "textarea",
     label: "描述",
     name: "description",
     required: true,
@@ -100,23 +100,23 @@ let formItems: IMesonFieldItem[] = [
 
 let formItems2: IMesonFieldItem[] = [
   {
-    type: EMesonFieldType.Decorative,
+    type: "decorative",
     render: () => "Custom errorClassName",
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     label: "username",
     name: "username",
     required: true,
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     label: "password",
     name: "password",
     required: true,
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     label: "lang text",
     name: "lang-text",
     required: true,

--- a/example/forms/wrap-meson-core.tsx
+++ b/example/forms/wrap-meson-core.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css } from "emotion";
 import { useMesonCore } from "../../src/hook/meson-core";
-import { IMesonCustomField, EMesonFieldType, IMesonFieldItem, EMesonValidate } from "../../src/model/types";
+import { IMesonCustomField, IMesonFieldItem, EMesonValidate } from "../../src/model/types";
 import { column } from "@jimengio/shared-utils";
 import { DocDemo, DocSnippet, DocBlock } from "@jimengio/doc-frame";
 import { getLink } from "util/link";
@@ -13,14 +13,14 @@ interface ILoginForm {
 
 let formItems: IMesonFieldItem<ILoginForm>[] = [
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "username",
     label: null,
     placeholder: "Username",
     required: true,
   },
   {
-    type: EMesonFieldType.Input,
+    type: "input",
     name: "password",
     inputType: "password",
     placeholder: "Password",
@@ -71,7 +71,7 @@ let WrapMesonCore: FC<{}> = (props) => {
         <div className={styleFormArea}>
           {formItems.map((item) => {
             switch (item.type) {
-              case EMesonFieldType.Input:
+              case "input":
                 return (
                   <div className={column} key={item.name}>
                     <input

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.4.0-a1",
+  "version": "0.4.0-a2",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.3.11",
+  "version": "0.4.0-a1",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/form-forwarded.tsx
+++ b/src/form-forwarded.tsx
@@ -78,11 +78,9 @@ export function ForwardForm<T = IMesonFormBase>(props: MesonFormProps<T>, ref: R
   let renderValueItem = (item: IMesonFieldItem<T>) => {
     switch (item.type) {
       case EMesonFieldType.Input:
-        if (item.textarea) {
-          return renderTextAreaItem(form, item, updateItem, checkItem);
-        }
         return renderInputItem(form, item, updateItem, checkItem, checkItemWithValue);
-
+      case EMesonFieldType.Textarea:
+        return renderTextAreaItem(form, item, updateItem, checkItem);
       case EMesonFieldType.Number:
         return renderNumberItem(form, item, updateItem, checkItem);
       case EMesonFieldType.Switch:

--- a/src/form-forwarded.tsx
+++ b/src/form-forwarded.tsx
@@ -1,7 +1,7 @@
 import React, { ReactText } from "react";
 import { row, column, flex, displayFlex, flexWrap } from "@jimengio/shared-utils";
 import { css, cx } from "emotion";
-import { IMesonFieldItem, EMesonFieldType, FuncMesonModifyForm, IMesonErrors, IMesonFormBase, IMesonFieldBaseProps } from "./model/types";
+import { IMesonFieldItem, FuncMesonModifyForm, IMesonErrors, IMesonFormBase, IMesonFieldBaseProps } from "./model/types";
 
 import { useMesonCore } from "./hook/meson-core";
 import { showErrorByNames } from "./util/validation";
@@ -77,17 +77,17 @@ export function ForwardForm<T = IMesonFormBase>(props: MesonFormProps<T>, ref: R
 
   let renderValueItem = (item: IMesonFieldItem<T>) => {
     switch (item.type) {
-      case EMesonFieldType.Input:
+      case "input":
         return renderInputItem(form, item, updateItem, checkItem, checkItemWithValue);
-      case EMesonFieldType.Textarea:
+      case "textarea":
         return renderTextAreaItem(form, item, updateItem, checkItem);
-      case EMesonFieldType.Number:
+      case "number":
         return renderNumberItem(form, item, updateItem, checkItem);
-      case EMesonFieldType.Switch:
+      case "switch":
         return renderSwitchItem(form, item, updateItem, checkItemWithValue);
-      case EMesonFieldType.Select:
+      case "select":
         return renderSelectItem(form, item, updateItem, checkItem, checkItemWithValue);
-      case EMesonFieldType.Custom:
+      case "custom":
       // already handled outside
     }
     return <div>Unknown type: {(item as any).type}</div>;
@@ -105,7 +105,7 @@ export function ForwardForm<T = IMesonFormBase>(props: MesonFormProps<T>, ref: R
         return null;
       }
 
-      if (item.type === EMesonFieldType.Group) {
+      if (item.type === "group") {
         const nextItemWidth = item.itemWidth != null ? item.itemWidth : itemWidth;
         const mergeClassName = item.horizontal ? cx(displayFlex, flexWrap) : undefined;
 
@@ -119,7 +119,7 @@ export function ForwardForm<T = IMesonFormBase>(props: MesonFormProps<T>, ref: R
       let name: string = (item as any).name;
       let error = name != null ? errors[name] : null;
 
-      if (item.type === EMesonFieldType.Custom) {
+      if (item.type === "custom") {
         let onChange = (value: any) => {
           updateItem(value, item);
         };
@@ -131,7 +131,7 @@ export function ForwardForm<T = IMesonFormBase>(props: MesonFormProps<T>, ref: R
         return renderItemLayout(key, item, error, item.render(form[item.name], onChange, form, onCheck), props.labelClassName, props.errorClassName, hideLabel);
       }
 
-      if (item.type === EMesonFieldType.CustomMultiple) {
+      if (item.type === "custom-multiple") {
         let modifidForm: FuncMesonModifyForm = (f) => {
           updateForm(f);
         };
@@ -155,11 +155,11 @@ export function ForwardForm<T = IMesonFormBase>(props: MesonFormProps<T>, ref: R
         );
       }
 
-      if (item.type === EMesonFieldType.Nested) {
+      if (item.type === "nested") {
         return renderItemLayout(key, item as any, error, renderItems(item.children, undefined, key), props.labelClassName, props.errorClassName, hideLabel);
       }
 
-      if (item.type === EMesonFieldType.Decorative) {
+      if (item.type === "decorative") {
         return renderDecorativeItem(key, form, item);
       }
 

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -71,11 +71,9 @@ export function useMesonItems<T = IMesonFormBase>(props: MesonFormProps<T>) {
   let renderValueItem = (item: IMesonFieldItem<T>) => {
     switch (item.type) {
       case EMesonFieldType.Input:
-        if (item.textarea) {
-          return renderTextAreaItem(form, item, updateItem, checkItem);
-        }
         return renderInputItem(form, item, updateItem, checkItem, checkItemWithValue);
-
+      case EMesonFieldType.Textarea:
+        return renderTextAreaItem(form, item, updateItem, checkItem);
       case EMesonFieldType.Number:
         return renderNumberItem(form, item, updateItem, checkItem);
       case EMesonFieldType.Switch:

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, CSSProperties, ReactText } from "react";
 import { row, column, flex, flexWrap, displayFlex } from "@jimengio/shared-utils";
 import { css, cx } from "emotion";
-import { IMesonFieldItem, EMesonFieldType, FuncMesonModifyForm, IMesonErrors, IMesonFormBase, IMesonFieldBaseProps } from "./model/types";
+import { IMesonFieldItem, FuncMesonModifyForm, IMesonErrors, IMesonFormBase, IMesonFieldBaseProps } from "./model/types";
 import { DropdownArea } from "@jimengio/dropdown";
 
 import { FormFooter, EMesonFooterLayout } from "./component/form-footer";
@@ -70,19 +70,19 @@ export function useMesonItems<T = IMesonFormBase>(props: MesonFormProps<T>) {
 
   let renderValueItem = (item: IMesonFieldItem<T>) => {
     switch (item.type) {
-      case EMesonFieldType.Input:
+      case "input":
         return renderInputItem(form, item, updateItem, checkItem, checkItemWithValue);
-      case EMesonFieldType.Textarea:
+      case "textarea":
         return renderTextAreaItem(form, item, updateItem, checkItem);
-      case EMesonFieldType.Number:
+      case "number":
         return renderNumberItem(form, item, updateItem, checkItem);
-      case EMesonFieldType.Switch:
+      case "switch":
         return renderSwitchItem(form, item, updateItem, checkItemWithValue);
-      case EMesonFieldType.Select:
+      case "select":
         return renderSelectItem(form, item, updateItem, checkItem, checkItemWithValue);
-      case EMesonFieldType.Radio:
+      case "radio":
         return renderRadioItem(form, item, updateItem, checkItemWithValue);
-      case EMesonFieldType.Custom:
+      case "custom":
       // already handled outside
     }
     return <div>Unknown type: {(item as any).type}</div>;
@@ -100,7 +100,7 @@ export function useMesonItems<T = IMesonFormBase>(props: MesonFormProps<T>) {
         return null;
       }
 
-      if (item.type === EMesonFieldType.Group) {
+      if (item.type === "group") {
         const nextItemWidth = item.itemWidth != null ? item.itemWidth : itemWidth;
         const mergeClassName = item.horizontal ? cx(displayFlex, flexWrap) : undefined;
 
@@ -114,7 +114,7 @@ export function useMesonItems<T = IMesonFormBase>(props: MesonFormProps<T>) {
       let name: string = (item as any).name;
       let error = name != null ? errors[name] : null;
 
-      if (item.type === EMesonFieldType.Custom) {
+      if (item.type === "custom") {
         let onChange = (value: any) => {
           updateItem(value, item);
         };
@@ -135,7 +135,7 @@ export function useMesonItems<T = IMesonFormBase>(props: MesonFormProps<T>) {
         );
       }
 
-      if (item.type === EMesonFieldType.CustomMultiple) {
+      if (item.type === "custom-multiple") {
         let modifidForm: FuncMesonModifyForm = (f) => {
           updateForm(f);
         };
@@ -159,11 +159,11 @@ export function useMesonItems<T = IMesonFormBase>(props: MesonFormProps<T>) {
         );
       }
 
-      if (item.type === EMesonFieldType.Nested) {
+      if (item.type === "nested") {
         return renderItemLayout(key, item as any, error, renderItems(item.children, undefined, key), props.labelClassName, props.errorClassName, hideLabel);
       }
 
-      if (item.type === EMesonFieldType.Decorative) {
+      if (item.type === "decorative") {
         return renderDecorativeItem(key, form, item);
       }
 

--- a/src/inline-form.tsx
+++ b/src/inline-form.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { useMesonCore } from "./hook/meson-core";
-import { EMesonFieldType, IMesonFieldItem, FuncMesonModifyForm, IMesonErrors } from "./model/types";
+import { IMesonFieldItem, FuncMesonModifyForm, IMesonErrors } from "./model/types";
 import { column, row } from "@jimengio/shared-utils";
 import { CSSProperties } from "@emotion/serialize";
 import Input from "antd/lib/input";
@@ -34,7 +34,7 @@ export function MesonInlineForm<T>(props: {
 
   let renderItem = (item: IMesonFieldItem<T>, idx: number) => {
     switch (item.type) {
-      case EMesonFieldType.Custom:
+      case "custom":
         let onChange = (value: any) => {
           updateItem(value, item);
         };
@@ -43,7 +43,7 @@ export function MesonInlineForm<T>(props: {
           checkItemWithValue(value, item);
         };
         return item.render(formAny[item.name], onChange, formAny, onCheck);
-      case EMesonFieldType.Input:
+      case "input":
         return (
           <Input
             value={formAny[item.name]}
@@ -72,7 +72,7 @@ export function MesonInlineForm<T>(props: {
           />
         );
 
-      case EMesonFieldType.Select:
+      case "select":
         let currentValue = formAny[item.name];
         if (item.translateNonStringvalue && currentValue != null) {
           currentValue = `${currentValue}`;
@@ -119,19 +119,19 @@ export function MesonInlineForm<T>(props: {
   return (
     <div className={cx(row, styleContainer)}>
       {props.items.map((item, idx) => {
-        if (item.type === EMesonFieldType.Group) {
+        if (item.type === "group") {
           return <>{item.children.map(renderItem)}</>;
         }
 
-        if (item.type === EMesonFieldType.Nested) {
+        if (item.type === "nested") {
           return `Not supported type: ${item.type}`;
         }
 
-        if (item.type === EMesonFieldType.CustomMultiple) {
+        if (item.type === "custom-multiple") {
           return `Not supported type: ${item.type}`;
         }
 
-        if (item.type === EMesonFieldType.Decorative) {
+        if (item.type === "decorative") {
           return `Not supported type: ${item.type}`;
         }
 

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -51,7 +51,7 @@ export interface IMesonFieldBaseProps<T> {
 }
 
 export interface IMesonDecorativeField<T> {
-  type: EMesonFieldType.Decorative;
+  type: "decorative";
   render: (form: T) => ReactNode;
   className?: string;
   style?: React.CSSProperties;
@@ -60,7 +60,7 @@ export interface IMesonDecorativeField<T> {
 
 export interface IMesonInputField<T> extends IMesonFieldBaseProps<T> {
   name: string;
-  type: EMesonFieldType.Input;
+  type: "input";
   /** real type property on <input/> */
   inputType?: string;
   inputProps?: InputProps;
@@ -80,7 +80,7 @@ export interface IMesonInputField<T> extends IMesonFieldBaseProps<T> {
 
 export interface IMesonTexareaField<T> extends IMesonFieldBaseProps<T> {
   name: string;
-  type: EMesonFieldType.Textarea;
+  type: "textarea";
   textareaProps?: TextAreaProps;
   placeholder?: string;
   /** false by default, "" and " " will emit value `undefined` */
@@ -98,7 +98,7 @@ export interface IMesonTexareaField<T> extends IMesonFieldBaseProps<T> {
 
 export interface IMesonNumberField<T> extends IMesonFieldBaseProps<T> {
   name: string;
-  type: EMesonFieldType.Number;
+  type: "number";
   placeholder?: string;
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
@@ -111,7 +111,7 @@ export interface IMesonNumberField<T> extends IMesonFieldBaseProps<T> {
 
 export interface IMesonSwitchField<T> extends IMesonFieldBaseProps<T> {
   name: string;
-  type: EMesonFieldType.Switch;
+  type: "switch";
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
   validator?: FuncMesonValidator<T>;
@@ -133,7 +133,7 @@ export interface IMesonRadioItem {
 
 export interface IMesonSelectField<T> extends IMesonFieldBaseProps<T> {
   name: string;
-  type: EMesonFieldType.Select;
+  type: "select";
   placeholder?: string;
   options: IMesonSelectItem[];
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>) => void;
@@ -147,7 +147,7 @@ export interface IMesonSelectField<T> extends IMesonFieldBaseProps<T> {
 
 export interface IMesonCustomField<T> extends IMesonFieldBaseProps<T> {
   name: string;
-  type: EMesonFieldType.Custom;
+  type: "custom";
   /** parent container is using column,
    * for antd inputs with default with 100%, you need to take care of that by yourself
    * @param current value in this field
@@ -162,7 +162,7 @@ export interface IMesonCustomField<T> extends IMesonFieldBaseProps<T> {
 }
 
 export interface IMesonCustomMultipleField<T> extends IMesonFieldBaseProps<T> {
-  type: EMesonFieldType.CustomMultiple;
+  type: "custom-multiple";
   /** multiple fields to edit and to check
    * @param modifyForm accepts a function to modify the form
    * @param checkForm accepts an object of new values
@@ -175,12 +175,12 @@ export interface IMesonCustomMultipleField<T> extends IMesonFieldBaseProps<T> {
 }
 
 export interface IMesonNestedFields<T> extends IMesonFieldBaseProps<T> {
-  type: EMesonFieldType.Nested;
+  type: "nested";
   children: IMesonFieldItem<T>[];
 }
 
 export interface IMesonGroupFields<T> {
-  type: EMesonFieldType.Group;
+  type: "group";
   children: IMesonFieldItem<T>[];
   shouldHide?: (form: T) => boolean;
   /**
@@ -194,7 +194,7 @@ export interface IMesonGroupFields<T> {
 }
 
 export interface IMesonRadioField<T> extends IMesonFieldBaseProps<T> {
-  type: EMesonFieldType.Radio;
+  type: "radio";
   name: string;
   label: string;
   options: IMesonRadioItem[];

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -1,5 +1,5 @@
 import { ReactNode, ReactText } from "react";
-import { InputProps } from "antd/lib/input";
+import { InputProps, TextAreaProps } from "antd/lib/input";
 import { InputNumberProps } from "antd/lib/input-number";
 import { SelectProps } from "antd/lib/select";
 import { Draft } from "immer";
@@ -26,6 +26,7 @@ export type FuncMesonModifyForm<T = any> = (modifter: (form: Draft<T>) => void) 
 
 export enum EMesonFieldType {
   Input = "input",
+  Textarea = "textarea",
   Number = "number",
   Select = "select",
   Custom = "custom",
@@ -62,13 +63,29 @@ export interface IMesonInputField<T> extends IMesonFieldBaseProps<T> {
   type: EMesonFieldType.Input;
   /** real type property on <input/> */
   inputType?: string;
-  /** other props for input and textarea, actially need TextareaProps */
   inputProps?: InputProps;
   placeholder?: string;
   /** false by default, "" and " " will emit value `undefined` */
   useBlank?: boolean;
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>) => void;
-  textarea?: boolean;
+  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validator?: FuncMesonValidator<T>;
+  /** validate immediately after content change,
+   * by default validation performs after each blur event
+   */
+  checkOnChange?: boolean;
+  /** add styles to container of value, which is inside each field and around the value */
+  valueContainerClassName?: string;
+}
+
+export interface IMesonTexareaField<T> extends IMesonFieldBaseProps<T> {
+  name: string;
+  type: EMesonFieldType.Textarea;
+  textareaProps?: TextAreaProps;
+  placeholder?: string;
+  /** false by default, "" and " " will emit value `undefined` */
+  useBlank?: boolean;
+  onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
   validator?: FuncMesonValidator<T>;
   /** validate immediately after content change,
@@ -188,17 +205,19 @@ export interface IMesonRadioField<T> extends IMesonFieldBaseProps<T> {
 }
 
 // 默认any过渡
-export type IMesonFieldItemHasValue<T = any> = 
-  IMesonInputField<T> | 
-  IMesonNumberField<T> | 
-  IMesonSelectField<T> | 
-  IMesonCustomField<T> | 
-  IMesonRadioField<T> |
-  IMesonSwitchField<T>;
+export type IMesonFieldItemHasValue<T = any> =
+  | IMesonInputField<T>
+  | IMesonTexareaField<T>
+  | IMesonNumberField<T>
+  | IMesonSelectField<T>
+  | IMesonCustomField<T>
+  | IMesonRadioField<T>
+  | IMesonSwitchField<T>;
 
 // 默认any过渡
 export type IMesonFieldItem<T = any> =
   | IMesonInputField<T>
+  | IMesonTexareaField<T>
   | IMesonNumberField<T>
   | IMesonSelectField<T>
   | IMesonCustomField<T>

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -9,6 +9,7 @@ import {
   IMesonSwitchField,
   IMesonDecorativeField,
   IMesonRadioField,
+  IMesonTexareaField,
 } from "./model/types";
 import { css, cx } from "emotion";
 import Input from "antd/lib/input";
@@ -23,7 +24,7 @@ type FuncUpdateItem<T> = (x: any, item: IMesonFieldItemHasValue<T>) => void;
 type FuncCheckItem<T> = (item: IMesonFieldItemHasValue<T>) => void;
 type FuncCheckItemWithValue<T> = (x: any, item: IMesonFieldItemHasValue<T>) => void;
 
-export function renderTextAreaItem<T>(form: T, item: IMesonInputField<T>, updateItem: FuncUpdateItem<T>, checkItem: FuncCheckItem<T>) {
+export function renderTextAreaItem<T>(form: T, item: IMesonTexareaField<T>, updateItem: FuncUpdateItem<T>, checkItem: FuncCheckItem<T>) {
   return (
     <>
       <TextArea
@@ -37,8 +38,7 @@ export function renderTextAreaItem<T>(form: T, item: IMesonInputField<T>, update
         onBlur={(event: any) => {
           checkItem(item);
         }}
-        // should use TextareaProps, but for convenience
-        {...(item.inputProps as any)}
+        {...item.textareaProps}
       />
     </>
   );

--- a/src/util/render.ts
+++ b/src/util/render.ts
@@ -1,4 +1,4 @@
-import { IMesonFieldItem, EMesonFieldType, ISimpleObject } from "../model/types";
+import { IMesonFieldItem, ISimpleObject } from "../model/types";
 
 export let traverseItems = (xs: IMesonFieldItem[], form: ISimpleObject, method: (x: IMesonFieldItem) => void) => {
   xs.forEach((x) => {
@@ -7,11 +7,11 @@ export let traverseItems = (xs: IMesonFieldItem[], form: ISimpleObject, method: 
     }
 
     switch (x.type) {
-      case EMesonFieldType.CustomMultiple:
-      case EMesonFieldType.Decorative:
+      case "custom-multiple":
+      case "decorative":
         return;
-      case EMesonFieldType.Nested:
-      case EMesonFieldType.Group:
+      case "nested":
+      case "group":
         traverseItems(x.children, form, method);
       default:
         method(x);
@@ -25,11 +25,11 @@ export let traverseItemsReachCustomMultiple = (xs: IMesonFieldItem[], form: ISim
       return null;
     }
     switch (x.type) {
-      case EMesonFieldType.CustomMultiple:
+      case "custom-multiple":
         method(x);
         return;
-      case EMesonFieldType.Nested:
-      case EMesonFieldType.Group:
+      case "nested":
+      case "group":
         traverseItemsReachCustomMultiple(x.children, form, method);
       default:
         return;

--- a/src/util/validation.ts
+++ b/src/util/validation.ts
@@ -1,4 +1,4 @@
-import { EMesonFieldType, IMesonFieldItem, IMesonFieldItemHasValue, EMesonValidate, FuncMesonValidator, IMesonErrors } from "../model/types";
+import { IMesonFieldItem, IMesonFieldItemHasValue, EMesonValidate, FuncMesonValidator, IMesonErrors } from "../model/types";
 import { formatString, lingual } from "../lingual";
 import is from "is";
 


### PR DESCRIPTION
BREAKING CHANGE.

`Textarea` 现在改成了一个独立的类型, 对应的节点的类型用 `textareaProps`. 不再跟原先的 Input 换在一起.

```js
  {
    type: EMesonFieldType.Textarea,
    label: "描述",
    name: "description",
    textareaProps: {},
    required: true,
  },
```

原先的代码需要对应更改.
