### PR TITLE
ensure required rule used even validator exists

### DIFF
--- a/example/forms/validation.tsx
+++ b/example/forms/validation.tsx
@@ -16,8 +16,10 @@ let formItems: IMesonFieldItem[] = [
     required: true,
     label: "名称",
     name: "name",
+    validator: () => {
+      return undefined;
+    },
   },
-
   {
     type: "input",
     required: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.4.1",
+  "version": "0.4.2-a1",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/lingual/locales.edn
+++ b/src/lingual/locales.edn
@@ -4,7 +4,7 @@
   :locales {
     "cancel" {"zhCN" "取消", "enUS" "Cancel"}
     "confirm" {"zhCN" "确认", "enUS" "Confirm"}
-    "labelIsRequired" {"zhCN" "{label} 必填", "enUS" "{label} is required"}
+    "labelIsRequired" {"zhCN" "{label} 不可以为空", "enUS" "{label} is required"}
     "labelShouldBeBoolean" {"zhCN" "{label} 应该为布尔值", "enUS" "{label} should be a boolean"}
     "labelShouldBeNumber" {"zhCN" "{label} 应该为数字", "enUS" "{label} should be a number"}
     "labelShouldBeString" {"zhCN" "{label} 应该为字符串", "enUS" "{label} should be a string"}

--- a/src/lingual/zh-cn.ts
+++ b/src/lingual/zh-cn.ts
@@ -2,7 +2,7 @@ import { ILang } from "./interface";
 export const zhCN: ILang = {
   cancel: "取消",
   confirm: "确认",
-  labelIsRequired: "{label} 必填",
+  labelIsRequired: "{label} 不可以为空",
   labelShouldBeBoolean: "{label} 应该为布尔值",
   labelShouldBeNumber: "{label} 应该为数字",
   labelShouldBeString: "{label} 应该为字符串",

--- a/src/util/validation.ts
+++ b/src/util/validation.ts
@@ -36,11 +36,22 @@ export let validateByMethods = <T>(x: any, methods: (EMesonValidate | FuncMesonV
 
 export let validateItem = <T>(x: any, item: IMesonFieldItemHasValue<T>, formValue: T): string => {
   if (item.validator != null) {
-    return item.validator(x, item, formValue);
-  } else if (is.array(item.validateMethods)) {
-    return validateByMethods(x, item.validateMethods, item);
-  } else if (item.required) {
-    return validateValueRequired(x, item);
+    let ret = item.validator(x, item, formValue);
+    if (ret != null) {
+      return ret;
+    }
+  }
+  if (is.array(item.validateMethods)) {
+    let ret = validateByMethods(x, item.validateMethods, item);
+    if (ret != null) {
+      return ret;
+    }
+  }
+  if (item.required) {
+    let ret = validateValueRequired(x, item);
+    if (ret != null) {
+      return ret;
+    }
   }
   return undefined;
 };


### PR DESCRIPTION
原先的逻辑, `validator` 方法存在的时候, `required` 属性的行为就被跳过了.. 设定的逻辑是只有要 required, 数据就不可以为 `null` 为 `""` 的.
