### PR TITLE
feature: add useMesonFields; support passing transferData

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ export let MesonForm: FC<{
   initialValue: any;
   /** JSON 结构的表单定义, 建议定义变量传过来, 一来定义会比较长, 二来 TS 类型推断在变量加类型的情况才准确 */
   items: IMesonFieldItem[];
-  onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: IMesonErrors) => void) => void;
+  onSubmit: (form: { [k: string]: any }, onServerErrors?: (x: IMesonErrors) => void, transferData?: any) => void;
   onCancel?: () => void;
   className?: string;
   /**

--- a/example/forms/use-items.tsx
+++ b/example/forms/use-items.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
-import { MesonForm, useMesonItems } from "../../src/form";
+import { useMesonFields } from "../../src/form";
 import { IMesonFieldItem, IMesonSelectItem } from "../../src/model/types";
 import { row, Space } from "@jimengio/flex-styles";
 import DataPreview from "kits/data-preview";
@@ -18,80 +18,10 @@ let formItems: IMesonFieldItem[] = [
   { type: "select", name: "city", options: selectItems, label: "城市", allowClear: true },
 ];
 
-let intro = `
-使用 \`useMesonItems\` 可以得到 items 的 UI 再自由进行组合, 没有内置组件 Footer 的局限.
-`;
-
-let contentInternals = `
-\`formElements\` 是渲染完成的 Virtual DOM, 需要加入到父组件的 DOM 树当中. \`onCheckSubmit\` 是触发表单进行校验和提交的方法, 需要绑定到外部的按钮上.
-
-\`initialValue\` 传入以后就是组件维护的内部状态, 通过 \`formInternals.formData\` 来获取实时的数据, 通过 \`formInternals.updateForm\` 可以通过 immer 更新.
-类似还有 \`formInternals.updateErrors\` 用于修改报错信息.
-`;
-
-let contentResetForm = `业务当中开始编辑表单使用 \`formInternals.resetForm(data)\` API, 除了重置数据, 同时清空的报错信息. 对应 updateForm updateErrors 的功能.`;
-
-let code = `
-import { useMesonItems } from "@jimengio/meson-form";
-
-let formItems: IMesonFieldItem[] = [
-  { type: 'input', name: "name", label: "名字", required: true },
-  { type: 'select', name: "city", options: selectItems, label: "城市" },
-];
-
-let [formElements, onCheckSubmit, formInternals] = useMesonItems({
-  initialValue: {},
-  items: formItems,
-  onSubmit: (form) => {
-    console.log('After validation:', form);
-  },
-});
-`;
-
-let codeUse = `
-<div>
-  <div>{formElements}</div>
-
-  <div style={{ padding: 16 }}>
-    Custom UI
-
-    <JimoButton
-      onClick={() => {
-        formInternals.updateForm((draft) => {
-          draft.name = "JIMENGIO";
-        });
-      }}
-      text="Reset name"
-    />
-
-    <button onClick={onCheckSubmit}>onSubmit</button>
-  </div>
-</div>
-`;
-
-let codeCallback = `
-let [formElements, onCheckSubmit, formInternals] = useMesonItems({
-  initialValue: {},
-  items: formItems,
-  onSubmit: null,
-});
-
-onCheckSubmit({
-  onSubmit: (form) => {
-    console.log("submit when valid", form);
-  },
-});
-`;
-
-let contentCallback = `
-\`onCheckSubmit\` 有一个比较特殊的用法, 可以在参数当中传入 \`onSubmit\`, 校验通过时会调用这个 \`onSubmit\`.
-这样也就可以替代 props 当中的 \`onSubmit\` 使用, 而 props 当中就需要强行把 \`onSubmit\` 设置为 null 了.
-`;
-
 let FormUseItems: FC<{}> = (props) => {
   let [form, setForm] = useState({});
 
-  let [formElements, onCheckSubmit, formInternals] = useMesonItems({
+  let fieldsPlugin = useMesonFields({
     initialValue: form,
     items: formItems,
     onSubmit: (form) => {
@@ -99,17 +29,26 @@ let FormUseItems: FC<{}> = (props) => {
     },
   });
 
+  let transferPlugin = useMesonFields<any, string>({
+    initialValue: form,
+    items: formItems,
+    onSubmit: (form, _, transferData) => {
+      console.log(form, transferData);
+    },
+  });
+
   return (
     <div className={cx(styleContainer)}>
       <DocBlock content={intro}></DocBlock>
       <DocDemo title={"Hooks API for items"} link={getLink("use-items.tsx")} className={styleDemo}>
-        <div>{formElements}</div>
+        <div>{fieldsPlugin.ui}</div>
         <div style={{ padding: 16 }}>
           Custom UI
           <Space width={16} />
           <JimoButton
             onClick={() => {
-              formInternals.updateForm((draft) => {
+              fieldsPlugin.updateInternalForm((draft) => {
+                draft.city = undefined;
                 draft.name = "JIMENGIO";
               });
             }}
@@ -119,7 +58,7 @@ let FormUseItems: FC<{}> = (props) => {
           <JimoButton
             fillColor
             onClick={() => {
-              onCheckSubmit({
+              fieldsPlugin.checkAndSubmit({
                 onSubmit: (form) => {
                   console.log("when valid", form);
                 },
@@ -130,7 +69,7 @@ let FormUseItems: FC<{}> = (props) => {
         </div>
 
         <div className={styleData}>
-          <code>formInternals.formData</code>: <pre className={styleCode}>{JSON.stringify(formInternals.formData, null, 2)}</pre>
+          <code>formInternals.formData</code>: <pre className={styleCode}>{JSON.stringify(fieldsPlugin.formData, null, 2)}</pre>
         </div>
 
         <DataPreview data={form} />
@@ -147,6 +86,24 @@ let FormUseItems: FC<{}> = (props) => {
       <DocDemo title="Callback syntax">
         <DocBlock content={contentCallback} />
         <DocSnippet code={codeCallback} />
+      </DocDemo>
+
+      <DocDemo title={"transferData"} link={getLink("use-items.tsx")} className={styleDemo}>
+        <DocBlock content={transferContent} />
+        <div>{transferPlugin.ui}</div>
+        <div className={row}>
+          <Space width={240} />
+          <JimoButton
+            fillColor
+            text="Submit"
+            onClick={() => {
+              transferPlugin.checkAndSubmit({
+                transferData: "data passed",
+              });
+            }}
+          ></JimoButton>
+        </div>
+        <DocSnippet code={transferCode} />
       </DocDemo>
     </div>
   );
@@ -167,4 +124,91 @@ let styleData = css`
 let styleCode = css`
   padding: 16px;
   background-color: hsl(0, 0%, 97%);
+`;
+
+let intro = `
+使用 \`useMesonFields\` 可以得到 items 的 UI 再自由进行组合, 没有内置组件 Footer 的局限.
+`;
+
+let contentInternals = `
+\`formElements\` 是渲染完成的 Virtual DOM, 需要加入到父组件的 DOM 树当中. \`onCheckSubmit\` 是触发表单进行校验和提交的方法, 需要绑定到外部的按钮上.
+
+\`initialValue\` 传入以后就是组件维护的内部状态, 通过 \`fieldsPlugin.formData\` 来获取实时的数据, 通过 \`fieldsPlugin.updateInternalForm\` 来倾向修改内部状态.
+`;
+
+let contentResetForm = `业务当中开始编辑表单使用 \`formInternals.resetForm(data)\` API, 除了重置数据, 同时清空的报错信息. 对应 \`updateInternalForm\` \`updateInternalErrors\` 的功能.`;
+
+let code = `
+import { useMesonFields } from "@jimengio/meson-form";
+
+let formItems: IMesonFieldItem[] = [
+  { type: 'input', name: "name", label: "名字", required: true },
+  { type: 'select', name: "city", options: selectItems, label: "城市" },
+];
+
+let fieldsPlugin = useMesonFields({
+  initialValue: {},
+  items: formItems,
+  onSubmit: (form) => {
+    console.log('After validation:', form);
+  },
+});
+`;
+
+let codeUse = `
+<div>
+  <div>{fieldsPlugin.ui}</div>
+
+  <div style={{ padding: 16 }}>
+    Custom UI
+
+    <JimoButton
+      onClick={() => {
+        fieldsPlugin.updateInternalForm((draft) => {
+          draft.name = "JIMENGIO";
+        });
+      }}
+      text="Reset name"
+    />
+
+    <button onClick={fieldsPlugin.checkAndSubmit}>onSubmit</button>
+  </div>
+</div>
+`;
+
+let codeCallback = `
+let fieldsPlugin = useMesonFields({
+  initialValue: {},
+  items: formItems,
+  onSubmit: null,
+});
+
+fieldsPlugin.checkAndSubmit({
+  onSubmit: (form) => {
+    console.log("submit when valid", form);
+  },
+});
+`;
+
+let contentCallback = `
+\`fieldsPlugin.checkAndSubmit\` 有一个比较特殊的用法, 可以在参数当中传入 \`onSubmit\`, 校验通过时会调用这个 \`onSubmit\`.
+这样也就可以替代 props 当中的 \`onSubmit\` 使用, 而 props 当中就需要强行把 \`onSubmit\` 设置为 null 了.
+`;
+
+let transferCode = `
+let transferPlugin = useMesonFields<any, string>({
+  initialValue: form,
+  items: formItems,
+  onSubmit: (form, _, transferData) => {
+    console.log(form, transferData);
+  },
+});
+
+transferPlugin.checkAndSubmit({
+  transferData: "data passed",
+});
+`;
+
+let transferContent = `
+需要传递上下文的时候, 可以用 \`transferData\` 强行传递数据, 可以在定义的时候声明类型.
 `;

--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -40,7 +40,7 @@ let items: ISidebarEntry[] = [
     path: genRouter.home.name,
   },
   {
-    title: "Use Items from Hooks API",
+    title: "Use Fields from Hooks API",
     cnTitle: "Hooks API 用法",
     path: genRouter.useItems.name,
   },

--- a/src/form-forwarded.tsx
+++ b/src/form-forwarded.tsx
@@ -52,7 +52,7 @@ export function ForwardForm<T extends FieldValues = FieldValues>(props: MesonFor
     checkItemWithValue,
     checkItemCustomMultiple,
     resetModified,
-  } = useMesonCore<T>({
+  } = useMesonCore<T, any>({
     initialValue: props.initialValue,
     items: props.items,
     submitOnEdit: props.submitOnEdit,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { MesonFormProps, MesonForm, MesonFormModal, MesonFormDrawer, MesonFormDropdown, useMesonItems } from "./form";
+export { MesonFormProps, MesonForm, MesonFormModal, MesonFormDrawer, MesonFormDropdown, useMesonFields, useMesonItems } from "./form";
 export { useFilterForm, IFilterFieldItem } from "./filter-form/core";
 
 export { MesonFormForwarded } from "./form-forwarded";

--- a/src/inline-form.tsx
+++ b/src/inline-form.tsx
@@ -25,7 +25,7 @@ export function MesonInlineForm<T extends FieldValues>(props: {
     props.onSubmit(form);
   };
 
-  let { formAny, errors, onCheckSubmit, checkItem, updateItem, checkItemWithValue } = useMesonCore<T>({
+  let { formAny, errors, onCheckSubmit, checkItem, updateItem, checkItemWithValue } = useMesonCore<T, any>({
     initialValue: props.initialValue,
     items: props.items,
     onSubmit: onSubmit,


### PR DESCRIPTION
`useMesonItems` 用的数组作为返回结果, 随着功能扩展, 使用不够方便, 后面加了 `formInternals` 强行暴露多个方法/属性, 现在用 `useMesonFields` 统一成对象的写法. 原先的写法, 兼容也是在的.

`transferData` 是为了修复传递上下文的问题, 比如这样一个写法, 上下文 `item.id` 无法直接传到 submit 的地方去, 简单粗暴的结构是用 `useRef` 临时存储,

```js
let fieldsPlugin = useMesonFields({
  initialValue: {},
  items: formItems,
  onSubmit: (form) => {
    console.log('After validation:', form);
  },
});

data.map(item => {
  return <div onClick={() => {
    // 上下文 item.id 
    fieldsPlugin.checkAndSubmit()
  }}>
  </div>
})
```

现在强行加上一个 `transferData`, 传递到 `onSubmit` 的位置, 实现有点乱, 至少能传递过去了.

```js
let transferPlugin = useMesonFields<any, string>({
  initialValue: form,
  items: formItems,
  onSubmit: (form, _, transferData) => {
    console.log(form, transferData);
  },
});

data.map(item => {
  return <div onClick={() => {
    // 上下文 item.id 
    fieldsPlugin.checkAndSubmit({
      transferData: item.id,
    })
  }}>
  </div>
})
```