### PR TITLE
fix textarea half pixel box shadow flicking in chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-form",
-  "version": "0.4.14",
+  "version": "0.4.15-a2",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/filter-form/core.tsx
+++ b/src/filter-form/core.tsx
@@ -93,7 +93,7 @@ let styleItemsContainer = css`
 let styleValueArea = css`
   min-width: 220px;
   width: 220px;
-  overflow: auto;
+  overflow: unset;
 `;
 
 let styleLabel = css`

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -501,7 +501,7 @@ let styleErrorWrapper = css`
 `;
 
 let styleValueArea = css`
-  overflow: auto;
+  overflow: unset;
 `;
 
 let styleLabel = css`


### PR DESCRIPTION
遇到半像素的情况, box-shadow 显示不正常并且伴随抖动, 基本认为跟 overflow 遮挡有关, 而且容器位置半像素的情况容易出现.

![image](https://user-images.githubusercontent.com/25790987/83858657-665f5480-a74f-11ea-8718-c1f7d8811c33.png)

去除 overflow auto 大致看下来布局还是正常, 需要担心某些特殊布局会不会有影响风险.