### PR TITLE
very initial solution for async validation

### DIFF
--- a/example/controller/generated-router.ts
+++ b/example/controller/generated-router.ts
@@ -189,6 +189,12 @@ export let genRouter = {
     path: () => `/preview-mode`,
     go: () => switchPath(`/preview-mode`),
   },
+  asyncValidation: {
+    name: "async-validation",
+    raw: "async-validation",
+    path: () => `/async-validation`,
+    go: () => switchPath(`/async-validation`),
+  },
   $: {
     name: "home",
     raw: "",
@@ -231,6 +237,7 @@ export interface GenRouterTypeTree {
     | GenRouterTypeTree["inputSuffix"]
     | GenRouterTypeTree["customTheme"]
     | GenRouterTypeTree["previewMode"]
+    | GenRouterTypeTree["asyncValidation"]
     | GenRouterTypeTree["$"];
   home: {
     name: "home";
@@ -402,6 +409,12 @@ export interface GenRouterTypeTree {
   };
   previewMode: {
     name: "preview-mode";
+    params: {};
+    query: {};
+    next: null;
+  };
+  asyncValidation: {
+    name: "async-validation";
     params: {};
     query: {};
     next: null;

--- a/example/forms/async-validation.tsx
+++ b/example/forms/async-validation.tsx
@@ -1,0 +1,264 @@
+import React, { FC, useState } from "react";
+import { css, cx } from "emotion";
+import { MesonForm } from "../../src/form";
+import { IMesonFieldItem, IMesonSelectItem } from "../../src/model/types";
+import DataPreview from "kits/data-preview";
+import { DocDemo, DocBlock, DocSnippet } from "@jimengio/doc-frame";
+import { getLink } from "util/link";
+import Input from "antd/lib/input";
+
+let formItems: IMesonFieldItem[] = [
+  {
+    type: "input",
+    name: "familyName",
+    label: "姓",
+    required: true,
+    placeholder: "不能有数字",
+    asyncValidator: async (x, item, form) => {
+      await new Promise((resolve, reject) => {
+        setTimeout(() => {
+          resolve();
+        }, 1000);
+      });
+      if (x?.match(/\d/)) {
+        return "should not have digits in name";
+      }
+    },
+  },
+  {
+    type: "input",
+    name: "givenName",
+    label: "名",
+    required: true,
+    placeholder: "不能有数字(异步), 标点(本地)",
+    validator: (x: string) => {
+      if (x?.match(/[\+\-\*\.\>\<\?]/)) {
+        return "should not contain punctuations";
+      }
+    },
+    asyncValidator: async (x: string) => {
+      await new Promise((resolve, reject) => {
+        setTimeout(() => {
+          resolve();
+        }, 1000);
+      });
+
+      if (x?.match(/\d/)) {
+        return "should not have digits in name";
+      }
+    },
+  },
+
+  {
+    type: "custom-multiple",
+    names: ["province", "city"],
+    label: "地区",
+    renderMultiple: (form, updateForm, checkForm) => {
+      return (
+        <div className={styleRow}>
+          Provice:{" "}
+          <Input
+            value={form.province}
+            style={{ width: 100 }}
+            placeholder={"不能有数字"}
+            onChange={(e) => {
+              let text = e.target.value;
+              updateForm((draft) => {
+                draft.province = text;
+              });
+            }}
+            onBlur={() => {
+              checkForm(form);
+            }}
+          />
+          City:
+          <Input
+            value={form.city}
+            style={{ width: 100 }}
+            placeholder={"不能有数字"}
+            onChange={(e) => {
+              let text = e.target.value;
+              updateForm((draft) => {
+                draft.city = text;
+              });
+            }}
+            onBlur={() => {
+              checkForm(form);
+            }}
+          />
+        </div>
+      );
+    },
+    validateMultiple: (form) => {
+      return {};
+    },
+    asyncValidateMultiple: async (form) => {
+      await new Promise((resolve, reject) => {
+        setTimeout(() => {
+          resolve();
+        }, 1000);
+      });
+      let ret = {
+        province: undefined,
+        city: undefined,
+      };
+      if (form.province?.match(/\d/)) {
+        ret.province = "should not contain digits";
+      }
+      if (form.city?.match(/\d/)) {
+        ret.city = "should not contain digits";
+      }
+      return ret;
+    },
+  },
+];
+
+let FormAsyncValidation: FC<{}> = (props) => {
+  let [form, setForm] = useState({});
+
+  return (
+    <div className={cx(styleContainer)}>
+      <DocBlock content={content}></DocBlock>
+      <DocDemo title={"A basic form"} link={getLink("basic.tsx")} className={styleDemo}>
+        <MesonForm
+          initialValue={form}
+          items={formItems}
+          onSubmit={(form) => {
+            setForm(form);
+          }}
+        />
+        <DataPreview data={form} />
+        <DocSnippet code={code} />
+
+        <DocBlock content={contentOfMultiple} />
+        <DocSnippet code={codeOfMultiple} />
+      </DocDemo>
+    </div>
+  );
+};
+
+export default FormAsyncValidation;
+
+let styleContainer = css``;
+
+let styleDemo = css`
+  min-width: 400px;
+`;
+
+let content = `
+\`asyncValidator\` 是一个用于异步校验的方法, 如果本地没有发现错误且该方法存在, 则会发起校验.
+`;
+
+let code = `
+import { MesonForm, IMesonFieldItem } from "@jimengio/meson-form";
+
+{
+  type: "input",
+  name: "familyName",
+  label: "姓",
+  required: true,
+  asyncValidator: async (x, item, form) => {
+    await new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve();
+      }, 1000);
+    });
+    if (x?.match(/\d/)) {
+      return "should not have digits in name";
+    }
+  },
+},
+{
+  type: "input",
+  name: "givenName",
+  label: "名",
+  required: true,
+  validator: (x: string) => {
+    if (x?.match(/[\\+\\-\\*\\.\\>\\<\\?]/)) {
+      return "should not contain punctuations";
+    }
+  },
+  asyncValidator: async (x: string) => {
+    await new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve();
+      }, 1000);
+    });
+
+    if (x?.match(/\d/)) {
+      return "should not have digits in name";
+    }
+  },
+},
+`;
+
+let contentOfMultiple = `
+\`asyncValidateMultiple\` 对应到 custom-multiple 类型当中的异步校验.
+`;
+
+let codeOfMultiple = `
+{
+  type: "custom-multiple",
+  names: ["province", "city"],
+  label: "地区",
+  renderMultiple: (form, updateForm, checkForm) => {
+    return (
+      <div className={styleRow}>
+        Provice:{" "}
+        <Input
+          value={form.province}
+          style={{ width: 100 }}
+          onChange={(e) => {
+            let text = e.target.value;
+            updateForm((draft) => {
+              draft.province = text;
+            });
+          }}
+          onBlur={() => {
+            checkForm(form);
+          }}
+        />
+        City:
+        <Input
+          value={form.city}
+          style={{ width: 100 }}
+          onChange={(e) => {
+            let text = e.target.value;
+            updateForm((draft) => {
+              draft.city = text;
+            });
+          }}
+          onBlur={() => {
+            checkForm(form);
+          }}
+        />
+      </div>
+    );
+  },
+  validateMultiple: (form) => {
+    return {};
+  },
+  asyncValidateMultiple: async (form) => {
+    await new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve();
+      }, 1000);
+    });
+    let ret = {
+      province: undefined,
+      city: undefined,
+    };
+    if (form.province?.match(/\d/)) {
+      ret.province = "should not contain digits";
+    }
+    if (form.city?.match(/\d/)) {
+      ret.city = "should not contain digits";
+    }
+    return ret;
+  },
+},
+`;
+
+let styleRow = css`
+  display: flex;
+`;

--- a/example/models/router-rules.ts
+++ b/example/models/router-rules.ts
@@ -32,5 +32,6 @@ export const routerRules: IRouteRule[] = [
   { path: "input-suffix" },
   { path: "custom-theme" },
   { path: "preview-mode" },
+  { path: "async-validation" },
   { path: "", name: "home" },
 ];

--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -34,6 +34,7 @@ import ExampleFilterForm from "forms/filter-form";
 import FormInputSuffix from "forms/input-suffix";
 import CustomThemePage from "./custom-theme";
 import PreviewMode from "./preview-mode";
+import FormAsyncValidation from "forms/async-validation";
 
 let items: ISidebarEntry[] = [
   {
@@ -176,6 +177,11 @@ let items: ISidebarEntry[] = [
     cnTitle: "定制主题",
     path: genRouter.customTheme.name,
   },
+  {
+    title: "Async validation",
+    cnTitle: "异步校验",
+    path: genRouter.asyncValidation.name,
+  },
 ];
 
 let onSwitchPage = (path: string) => {
@@ -244,6 +250,8 @@ let Container: FC<{ router: GenRouterTypeTree["next"] }> = (props) => {
         return <FormInputSuffix />;
       case "custom-theme":
         return <CustomThemePage />;
+      case "async-validation":
+        return <FormAsyncValidation />;
       default:
         return <FormBasic />;
     }

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -25,6 +25,7 @@ export enum EMesonValidate {
 }
 
 export type FuncMesonValidator<T> = (x: any, item?: IMesonFieldItemHasValue<T>, formValue?: T) => string;
+export type FuncMesonAsyncValidator<T> = (x: any, item?: IMesonFieldItemHasValue<T>, formValue?: T) => Promise<string>;
 
 /** expose a function to modify form values directly, FR-97
  * Caution, it does not trigger field validation! So don't use it to mofidy fields before current one.
@@ -82,10 +83,12 @@ export interface IMesonInputField<T extends FieldValues, K extends FieldName<T> 
   useBlank?: boolean;
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
-  validator?: FuncMesonValidator<T>;
   /** validate immediately after content change,
    * by default validation performs after each blur event
    */
+  validator?: FuncMesonValidator<T>;
+  /** async validation, it only works during single item check, and it's inactive during submit */
+  asyncValidator?: FuncMesonAsyncValidator<T>;
   checkOnChange?: boolean;
   /** add styles to container of value, which is inside each field and around the value */
   valueContainerClassName?: string;
@@ -104,10 +107,12 @@ export interface IMesonTexareaField<T extends FieldValues, K extends FieldName<T
   useBlank?: boolean;
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
-  validator?: FuncMesonValidator<T>;
   /** validate immediately after content change,
    * by default validation performs after each blur event
    */
+  validator?: FuncMesonValidator<T>;
+  /** async validation, it only works during single item check, and it's inactive during submit */
+  asyncValidator?: FuncMesonAsyncValidator<T>;
   enableCounter?: boolean;
   checkOnChange?: boolean;
   /** add styles to container of value, which is inside each field and around the value */
@@ -120,14 +125,16 @@ export interface IMesonNumberField<T extends FieldValues, K extends FieldName<T>
   placeholder?: string;
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  /** append icon/text after input box as suffix,
+   * since antd input use width:100%, a suffix node is actually placed out of base box
+   */
   validator?: FuncMesonValidator<T>;
+  /** async validation, it only works during single item check, and it's inactive during submit */
+  asyncValidator?: FuncMesonAsyncValidator<T>;
   min?: number;
   max?: number;
   inputProps?: InputNumberProps;
   valueContainerClassName?: string;
-  /** append icon/text after input box as suffix,
-   * since antd input use width:100%, a suffix node is actually placed out of base box
-   */
   suffixNode?: ReactNode;
 }
 
@@ -142,6 +149,8 @@ export interface IMesonDatePickerField<T extends FieldValues, K extends FieldNam
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
   validator?: FuncMesonValidator<T>;
+  /** async validation, it only works during single item check, and it's inactive during submit */
+  asyncValidator?: FuncMesonAsyncValidator<T>;
   datePickerProps?: DatePickerProps;
   valueContainerClassName?: string;
 }
@@ -156,6 +165,8 @@ export interface IMesonTreeSelectField<T extends FieldValues, K extends FieldNam
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
   validator?: FuncMesonValidator<T>;
+  /** async validation, it only works during single item check, and it's inactive during submit */
+  asyncValidator?: FuncMesonAsyncValidator<T>;
   treeSelectProps?: TreeSelectProps<TreeNodeValue>;
   valueContainerClassName?: string;
 }
@@ -186,6 +197,8 @@ export interface IMesonDropdownTreeField<T extends FieldValues, K extends FieldN
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
   validator?: FuncMesonValidator<T>;
+  /** async validation, it only works during single item check, and it's inactive during submit */
+  asyncValidator?: FuncMesonAsyncValidator<T>;
   treeSelectProps?: IFormDropdownTreeProps;
   valueContainerClassName?: string;
 }
@@ -196,6 +209,8 @@ export interface IMesonSwitchField<T extends FieldValues, K extends FieldName<T>
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
   validator?: FuncMesonValidator<T>;
+  /** async validation, it only works during single item check, and it's inactive during submit */
+  asyncValidator?: FuncMesonAsyncValidator<T>;
   valueContainerClassName?: string;
 }
 
@@ -220,6 +235,8 @@ export interface IMesonSelectField<T extends FieldValues, K extends FieldName<T>
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
   validator?: FuncMesonValidator<T>;
+  /** async validation, it only works during single item check, and it's inactive during submit */
+  asyncValidator?: FuncMesonAsyncValidator<T>;
   translateNonStringvalue?: boolean;
   allowClear?: boolean;
   selectProps?: SelectProps;
@@ -249,6 +266,8 @@ export interface IMesonDropdownSelectField<T extends FieldValues, K extends Fiel
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
   validator?: FuncMesonValidator<T>;
+  /** async validation, it only works during single item check, and it's inactive during submit */
+  asyncValidator?: FuncMesonAsyncValidator<T>;
   translateNonStringvalue?: boolean;
   allowClear?: boolean;
   selectProps?: IFormDropdownSelectProps;
@@ -269,6 +288,8 @@ export interface IMesonCustomField<T extends FieldValues, K extends FieldName<T>
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
   validator?: FuncMesonValidator<T>;
+  /** async validation, it only works during single item check, and it's inactive during submit */
+  asyncValidator?: FuncMesonAsyncValidator<T>;
 }
 
 export interface IMesonCustomMultipleField<T extends FieldValues, K1 extends FieldName<T> = FieldName<T>> extends IMesonFieldBaseProps<T> {
@@ -282,6 +303,7 @@ export interface IMesonCustomMultipleField<T extends FieldValues, K1 extends Fie
   renderMultiple: (form: T, modifyForm: FuncMesonModifyForm<T>, checkForm: (changedValues: Partial<T>) => void) => ReactNode;
   /** get form and return errors of related fields in object */
   validateMultiple?: (form: T, item: IMesonCustomMultipleField<T, K1>) => IMesonErrors<T>;
+  asyncValidateMultiple?: (form: T, item: IMesonCustomMultipleField<T, K1>) => Promise<IMesonErrors<T>>;
 }
 
 export interface IMesonNestedFields<T> extends IMesonFieldBaseProps<T> {
@@ -317,6 +339,8 @@ export interface IMesonRadioField<T extends FieldValues, K extends FieldName<T> 
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
   validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
   validator?: FuncMesonValidator<T>;
+  /** async validation, it only works during single item check, and it's inactive during submit */
+  asyncValidator?: FuncMesonAsyncValidator<T>;
   valueContainerClassName?: string;
 }
 

--- a/src/util/data.ts
+++ b/src/util/data.ts
@@ -1,0 +1,16 @@
+/** detects if no errors found */
+export let isEmptyErrorsObject = (x: object) => {
+  if (x == null) {
+    return true;
+  }
+
+  for (let k in x) {
+    let v = x[k];
+    if (v != null) {
+      // if non-empty data found, then it's not empty
+      return false;
+    }
+  }
+
+  return true;
+};


### PR DESCRIPTION
基础功能的异步校验支持. 单个表单项编辑完成时会触发一次异步校验.

当前实现不包含一些相关的功能,

* submit 时的校验只检查同步的 `validator` 方法, 而不会检查异步的 `asyncValidator`.
* 异步校验进行时, 不会有 loading 提示.

完整的功能涉及到的代码较多, 可能与已有的某些特殊功能冲突, 后续再考虑了. 暂时只对基础的异步校验增加支持.