### PR TITLE
basic support for registered render

### DIFF
--- a/example/controller/generated-router.ts
+++ b/example/controller/generated-router.ts
@@ -195,6 +195,12 @@ export let genRouter = {
     path: () => `/async-validation`,
     go: () => switchPath(`/async-validation`),
   },
+  registeredRenderer: {
+    name: "registered-renderer",
+    raw: "registered-renderer",
+    path: () => `/registered-renderer`,
+    go: () => switchPath(`/registered-renderer`),
+  },
   $: {
     name: "home",
     raw: "",
@@ -238,6 +244,7 @@ export interface GenRouterTypeTree {
     | GenRouterTypeTree["customTheme"]
     | GenRouterTypeTree["previewMode"]
     | GenRouterTypeTree["asyncValidation"]
+    | GenRouterTypeTree["registeredRenderer"]
     | GenRouterTypeTree["$"];
   home: {
     name: "home";
@@ -415,6 +422,12 @@ export interface GenRouterTypeTree {
   };
   asyncValidation: {
     name: "async-validation";
+    params: {};
+    query: {};
+    next: null;
+  };
+  registeredRenderer: {
+    name: "registered-renderer";
     params: {};
     query: {};
     next: null;

--- a/example/forms/registered-renderer.tsx
+++ b/example/forms/registered-renderer.tsx
@@ -1,0 +1,82 @@
+import React, { FC, useState } from "react";
+import { css, cx } from "emotion";
+import { MesonForm } from "../../src/form";
+import { IMesonFieldItem, IMesonSelectItem, IMesonRegisteredField } from "../../src/model/types";
+
+import DataPreview from "kits/data-preview";
+import { DocDemo, DocBlock, DocSnippet } from "@jimengio/doc-frame";
+import { getLink } from "util/link";
+import { registerMesonFormRenderer } from "../../src/registered-renderer";
+import Input from "antd/lib/input";
+import { rowMiddle, Space } from "@jimengio/flex-styles";
+
+registerMesonFormRenderer("my-input", (value, onChange, onCheck, form, options: { placeholder: string }, fieldItem) => {
+  return (
+    <div className={rowMiddle}>
+      my global input
+      <Space width={8} />
+      <Input
+        value={value}
+        style={{ width: 200 }}
+        placeholder={options.placeholder}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
+        onBlur={() => {
+          onCheck(value);
+        }}
+      />
+      <Space width={8} />
+      with texts
+    </div>
+  );
+});
+
+let formItems: IMesonFieldItem[] = [
+  {
+    type: "registered",
+    name: "name",
+    label: "名字",
+    required: true,
+    renderType: "my-input",
+    renderOptions: {
+      placeholder: "name field",
+    },
+  },
+];
+
+let FormRegisteredRenderer: FC<{}> = (props) => {
+  let [form, setForm] = useState({});
+
+  return (
+    <div className={cx(styleContainer)}>
+      <DocBlock content={content}></DocBlock>
+      <DocDemo title={"A basic form"} link={getLink("basic.tsx")} className={styleDemo}>
+        <MesonForm
+          initialValue={form}
+          items={formItems}
+          onSubmit={(form) => {
+            setForm(form);
+          }}
+        />
+        <DataPreview data={form} />
+        <DocSnippet code={code} />
+      </DocDemo>
+    </div>
+  );
+};
+
+export default FormRegisteredRenderer;
+
+let styleContainer = css``;
+
+let styleDemo = css`
+  min-width: 400px;
+`;
+
+let content = `
+`;
+
+let code = `
+
+`;

--- a/example/forms/registered-renderer.tsx
+++ b/example/forms/registered-renderer.tsx
@@ -75,8 +75,43 @@ let styleDemo = css`
 `;
 
 let content = `
+设置了 \`registerMesonFormRenderer\` 方法, 注册一个渲染函数, 这样表单使用的时候就可以用 \`renderType\` 和 \`renderOptions\` 控制调用渲染函数进行渲染.
+方便业务开发当中定义自己的通用渲染函数.
 `;
 
 let code = `
+registerMesonFormRenderer("my-input", (value, onChange, onCheck, form, options: { placeholder: string }, fieldItem) => {
+  return (
+    <div className={rowMiddle}>
+      my global input
+      <Space width={8} />
+      <Input
+        value={value}
+        style={{ width: 200 }}
+        placeholder={options.placeholder}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
+        onBlur={() => {
+          onCheck(value);
+        }}
+      />
+      <Space width={8} />
+      with texts
+    </div>
+  );
+});
 
+let formItems: IMesonFieldItem[] = [
+  {
+    type: "registered",
+    name: "name",
+    label: "名字",
+    required: true,
+    renderType: "my-input",
+    renderOptions: {
+      placeholder: "name field",
+    },
+  },
+];
 `;

--- a/example/models/router-rules.ts
+++ b/example/models/router-rules.ts
@@ -33,5 +33,6 @@ export const routerRules: IRouteRule[] = [
   { path: "custom-theme" },
   { path: "preview-mode" },
   { path: "async-validation" },
+  { path: "registered-renderer" },
   { path: "", name: "home" },
 ];

--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -35,6 +35,7 @@ import FormInputSuffix from "forms/input-suffix";
 import CustomThemePage from "./custom-theme";
 import PreviewMode from "./preview-mode";
 import FormAsyncValidation from "forms/async-validation";
+import FormRegisteredRenderer from "forms/registered-renderer";
 
 let items: ISidebarEntry[] = [
   {
@@ -182,6 +183,11 @@ let items: ISidebarEntry[] = [
     cnTitle: "异步校验",
     path: genRouter.asyncValidation.name,
   },
+  {
+    title: "Registered renderer",
+    cnTitle: "注册渲染器",
+    path: genRouter.registeredRenderer.name,
+  },
 ];
 
 let onSwitchPage = (path: string) => {
@@ -252,6 +258,8 @@ let Container: FC<{ router: GenRouterTypeTree["next"] }> = (props) => {
         return <CustomThemePage />;
       case "async-validation":
         return <FormAsyncValidation />;
+      case "registered-renderer":
+        return <FormRegisteredRenderer />;
       default:
         return <FormBasic />;
     }

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -27,6 +27,8 @@ import {
 import { lingual } from "./lingual";
 import { JimoButton } from "@jimengio/jimo-basics";
 import { createItemKey } from "./util/string";
+import { getFormRenderer } from "./registered-renderer";
+import { isFunction } from "lodash-es";
 
 export interface MesonFormProps<T extends FieldValues, TD = any> {
   initialValue: T;
@@ -145,6 +147,30 @@ export function useMesonFields<T = FieldValues, TD = any>(props: MesonFormProps<
           hideLabel,
           itemWidth
         );
+      }
+
+      if (item.type === "registered") {
+        let onChange = (value: any) => {
+          updateItem(value, item);
+        };
+
+        let onCheck = (value: any) => {
+          checkItemWithValue(value, item);
+        };
+
+        let renderFn = getFormRenderer(item.renderType);
+        let valueNode: ReactNode;
+        if (isFunction(renderFn)) {
+          valueNode = renderFn(form[item.name], onChange, onCheck, form as any, item.renderOptions || {}, item);
+        } else {
+          valueNode = (
+            <div className={styleRenderPlaceholder}>
+              failed to find renderer for {JSON.stringify(item.renderType)} {JSON.stringify(item.renderOptions)}
+            </div>
+          );
+        }
+
+        return renderItemLayout(key, item, error, valueNode, props.labelClassName, props.errorClassName, hideLabel, itemWidth);
       }
 
       if (item.type === "custom-multiple") {
@@ -434,4 +460,10 @@ let styleFooterButton = css`
 
 let styleFooterContainer = css`
   padding: 0px 12px 10px 12px;
+`;
+
+let styleRenderPlaceholder = css`
+  background-color: hsla(357, 91%, 55%, 1);
+  color: white;
+  padding: 0 6px;
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,5 @@ export { IMesonFieldItem, EMesonFieldType, IMesonSelectItem } from "./model/type
 export { default as FooterButtons, IFooterButtonOptions } from "./component/footer-buttons";
 
 export { attachMesonFormThemeVariables } from "./theme";
+
+export { registerMesonFormRenderer } from "./registered-renderer";

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -292,6 +292,26 @@ export interface IMesonCustomField<T extends FieldValues, K extends FieldName<T>
   asyncValidator?: FuncMesonAsyncValidator<T>;
 }
 
+export interface IMesonRegisteredField<T extends FieldValues, K extends FieldName<T> = FieldName<T>> extends IMesonFieldBaseProps<T> {
+  name: K;
+  type: "registered";
+  /** parent container is using column,
+   * for antd inputs with default with 100%, you need to take care of that by yourself
+   * @param current value in this field
+   * @param onChange update value in this field
+   * @param form the form
+   * @param onCheck pass in latest value and it will be validated based on rules. mostly called after blurred or selected.
+   */
+  onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
+  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validator?: FuncMesonValidator<T>;
+  /** async validation, it only works during single item check, and it's inactive during submit */
+  asyncValidator?: FuncMesonAsyncValidator<T>;
+  /** choose a globally registered renderer */
+  renderType: string;
+  renderOptions?: object;
+}
+
 export interface IMesonCustomMultipleField<T extends FieldValues, K1 extends FieldName<T> = FieldName<T>> extends IMesonFieldBaseProps<T> {
   type: "custom-multiple";
   /** multiple fields to edit and to check
@@ -356,6 +376,7 @@ export type IMesonFieldItemHasValue<T extends FieldValues = FieldValues, K exten
   | IMesonDatePickerField<T, K>
   | IMesonTreeSelectField<T, K>
   | IMesonDropdownTreeField<T, K>
+  | IMesonRegisteredField<T, K>
   | IMesonSwitchField<T, K>;
 
 // 默认any过渡
@@ -374,4 +395,5 @@ export type IMesonFieldItem<T extends FieldValues = FieldValues, K extends Field
   | IMesonDatePickerField<T, K>
   | IMesonTreeSelectField<T, K>
   | IMesonDropdownTreeField<T, K>
+  | IMesonRegisteredField<T, K>
   | IMesonCustomMultipleField<T, K>;

--- a/src/registered-renderer.tsx
+++ b/src/registered-renderer.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from "react";
+import { isFunction } from "util";
+import { IMesonRegisteredField } from "./model/types";
+
+type FuncValueRenderer = (
+  value: any,
+  onChange: (value: any) => void,
+  onCheck: (value: any) => void,
+  form?: object,
+  options?: object,
+  field?: IMesonRegisteredField<any>
+) => ReactNode;
+
+let fieldValueRenderers: { [k: string]: FuncValueRenderer } = {};
+
+export let registerMesonFormRenderer = (type: string, f: FuncValueRenderer) => {
+  if (fieldValueRenderers[type] != null) {
+    console.warn("[MesonForm] overwriting render type", type, fieldValueRenderers[type], f);
+  }
+  fieldValueRenderers[type] = f;
+};
+
+export let getFormRenderer = (type: string): FuncValueRenderer => {
+  if (isFunction(fieldValueRenderers[type])) {
+    return fieldValueRenderers[type];
+  }
+  console.warn("[MesonForm] unknown render type", JSON.stringify(type), "among", Object.keys(fieldValueRenderers), "resolved to", fieldValueRenderers[type]);
+  return null;
+};


### PR DESCRIPTION
Previews http://fe.jimu.io/meson-form/#/registered-renderer .

* 新增 API `registerMesonFormRenderer`
* 选择类型 `registered` 对应 `renderType` 和 `renderOptions` 这些属性.

大致对应 https://github.com/jimengio/rough-table/pull/69 . 允许业务做全局配置. 同样的动态类型的一些缺陷.