### PR TITLE
remove validateMethods, make use of validateRules

### DIFF
--- a/example/forms/draft.tsx
+++ b/example/forms/draft.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "meson-form";
 import { EMesonFooterLayout } from "../../src/component/form-footer";
-import { IMesonSelectItem, IMesonFieldItem, EMesonValidate } from "../../src/model/types";
+import { IMesonSelectItem, IMesonFieldItem } from "../../src/model/types";
 import Input from "antd/lib/input";
 import { row } from "@jimengio/flex-styles";
 import DataPreview from "kits/data-preview";
@@ -64,7 +64,7 @@ let formItems: IMesonFieldItem<IDemo>[] = [
     label: "计数",
     name: "count",
     required: true,
-    validateMethods: [EMesonValidate.Number],
+    validateRules: { type: "number", failText: "required a number", next: [{ type: "min", n: 0, failText: "less than zero" }] },
   },
   {
     type: "input",

--- a/example/forms/group.tsx
+++ b/example/forms/group.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import { MesonForm } from "meson-form";
 import { EMesonFooterLayout } from "../../src/component/form-footer";
-import { IMesonSelectItem, IMesonFieldItem, EMesonValidate } from "../../src/model/types";
+import { IMesonSelectItem, IMesonFieldItem } from "../../src/model/types";
 import Input from "antd/lib/input";
 import { row, expand } from "@jimengio/flex-styles";
 import DataPreview from "kits/data-preview";

--- a/example/forms/wrap-meson-core.tsx
+++ b/example/forms/wrap-meson-core.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import { css } from "emotion";
 import { useMesonCore } from "../../src/hook/meson-core";
-import { IMesonCustomField, IMesonFieldItem, EMesonValidate } from "../../src/model/types";
+import { IMesonCustomField, IMesonFieldItem } from "../../src/model/types";
 import { column } from "@jimengio/flex-styles";
 import { DocDemo, DocSnippet, DocBlock } from "@jimengio/doc-frame";
 import { getLink } from "util/link";

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-dom": "*"
   },
   "dependencies": {
+    "@jimengio/ruled-validator": "^0.1.1-a1",
     "lodash-es": "^4.17.15",
     "use-immer": "^0.4.0"
   }

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -9,21 +9,12 @@ import { Moment } from "moment";
 import { TreeSelectProps } from "antd/lib/tree-select";
 import { DefaultValueType } from "rc-tree-select/lib/interface";
 import { DatePickerProps } from "antd/lib/date-picker";
-
-export interface ISimpleObject<T = any> {
-  [k: string]: T;
-}
+import { RuledRuleEntry } from "@jimengio/ruled-validator";
 
 export type FieldValues = Record<string, any>;
 export type IMesonFormBase = FieldValues;
 export type FieldName<F extends FieldValues> = keyof F & string;
 export type IMesonErrors<T> = Partial<Record<FieldName<T>, string>>;
-
-export enum EMesonValidate {
-  Number = "number",
-  String = "string",
-  Boolean = "boolean",
-}
 
 export type FuncMesonValidator<T> = (x: any, item?: IMesonFieldItemHasValue<T>, formValue?: T) => string;
 export type FuncMesonAsyncValidator<T> = (x: any, item?: IMesonFieldItemHasValue<T>, formValue?: T) => Promise<string>;
@@ -85,7 +76,7 @@ export interface IMesonInputField<T extends FieldValues, K extends FieldName<T> 
   /** false by default, "" and " " will emit value `undefined` */
   useBlank?: boolean;
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
-  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validateRules?: RuledRuleEntry;
   /** validate immediately after content change,
    * by default validation performs after each blur event
    */
@@ -109,7 +100,7 @@ export interface IMesonTexareaField<T extends FieldValues, K extends FieldName<T
   /** false by default, "" and " " will emit value `undefined` */
   useBlank?: boolean;
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
-  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validateRules?: RuledRuleEntry;
   /** validate immediately after content change,
    * by default validation performs after each blur event
    */
@@ -127,7 +118,7 @@ export interface IMesonNumberField<T extends FieldValues, K extends FieldName<T>
   type: "number";
   placeholder?: string;
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
-  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validateRules?: RuledRuleEntry;
   /** append icon/text after input box as suffix,
    * since antd input use width:100%, a suffix node is actually placed out of base box
    */
@@ -150,7 +141,7 @@ export interface IMesonDatePickerField<T extends FieldValues, K extends FieldNam
   /** 组件选中的值, 设置到 form object 之前如果需要进行转换 */
   transformSelectedValue?: (clonedDateObj: Moment, dateString: string) => string;
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
-  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validateRules?: RuledRuleEntry;
   validator?: FuncMesonValidator<T>;
   /** async validation, it only works during single item check, and it's inactive during submit */
   asyncValidator?: FuncMesonAsyncValidator<T>;
@@ -166,7 +157,7 @@ export interface IMesonTreeSelectField<T extends FieldValues, K extends FieldNam
   disabled?: boolean;
   multiple?: boolean;
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
-  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validateRules?: RuledRuleEntry;
   validator?: FuncMesonValidator<T>;
   /** async validation, it only works during single item check, and it's inactive during submit */
   asyncValidator?: FuncMesonAsyncValidator<T>;
@@ -198,7 +189,7 @@ export interface IMesonDropdownTreeField<T extends FieldValues, K extends FieldN
   disabled?: boolean;
   options?: IDropdownTreeProps["items"];
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
-  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validateRules?: RuledRuleEntry;
   validator?: FuncMesonValidator<T>;
   /** async validation, it only works during single item check, and it's inactive during submit */
   asyncValidator?: FuncMesonAsyncValidator<T>;
@@ -210,7 +201,7 @@ export interface IMesonSwitchField<T extends FieldValues, K extends FieldName<T>
   name: K;
   type: "switch";
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
-  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validateRules?: RuledRuleEntry;
   validator?: FuncMesonValidator<T>;
   /** async validation, it only works during single item check, and it's inactive during submit */
   asyncValidator?: FuncMesonAsyncValidator<T>;
@@ -236,7 +227,7 @@ export interface IMesonSelectField<T extends FieldValues, K extends FieldName<T>
   placeholder?: string;
   options: IMesonSelectItem[];
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
-  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validateRules?: RuledRuleEntry;
   validator?: FuncMesonValidator<T>;
   /** async validation, it only works during single item check, and it's inactive during submit */
   asyncValidator?: FuncMesonAsyncValidator<T>;
@@ -267,7 +258,7 @@ export interface IMesonDropdownSelectField<T extends FieldValues, K extends Fiel
   options: IMesonSelectItem[];
   placeholder?: string;
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
-  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validateRules?: RuledRuleEntry;
   validator?: FuncMesonValidator<T>;
   /** async validation, it only works during single item check, and it's inactive during submit */
   asyncValidator?: FuncMesonAsyncValidator<T>;
@@ -289,7 +280,7 @@ export interface IMesonCustomField<T extends FieldValues, K extends FieldName<T>
    */
   render: (value: any, onChange: (x: any) => void, form: T, onCheck: (x: any) => void) => ReactNode;
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
-  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validateRules?: RuledRuleEntry;
   validator?: FuncMesonValidator<T>;
   /** async validation, it only works during single item check, and it's inactive during submit */
   asyncValidator?: FuncMesonAsyncValidator<T>;
@@ -306,7 +297,7 @@ export interface IMesonRegisteredField<T extends FieldValues, K extends FieldNam
    * @param onCheck pass in latest value and it will be validated based on rules. mostly called after blurred or selected.
    */
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
-  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validateRules?: RuledRuleEntry;
   validator?: FuncMesonValidator<T>;
   /** async validation, it only works during single item check, and it's inactive during submit */
   asyncValidator?: FuncMesonAsyncValidator<T>;
@@ -361,7 +352,7 @@ export interface IMesonRadioField<T extends FieldValues, K extends FieldName<T> 
   label: string;
   options: IMesonRadioItem[];
   onChange?: (x: any, modifyFormObject?: FuncMesonModifyForm<T>, internals?: IChangeInternals<T>) => void;
-  validateMethods?: (EMesonValidate | FuncMesonValidator<T>)[];
+  validateRules?: RuledRuleEntry;
   validator?: FuncMesonValidator<T>;
   /** async validation, it only works during single item check, and it's inactive during submit */
   asyncValidator?: FuncMesonAsyncValidator<T>;

--- a/src/util/validation.ts
+++ b/src/util/validation.ts
@@ -1,6 +1,7 @@
-import { IMesonFieldItemHasValue, EMesonValidate, FuncMesonValidator, IMesonErrors } from "../model/types";
+import { IMesonFieldItemHasValue, FuncMesonValidator, IMesonErrors } from "../model/types";
 import { formatString, lingual } from "../lingual";
 import { isNumber, isString, isBoolean, isFunction, isArray } from "lodash-es";
+import { ruledValidate } from "@jimengio/ruled-validator";
 
 export let validateValueRequired = <T>(x: any, item: IMesonFieldItemHasValue<T>) => {
   if (x == null || x === "") {
@@ -10,30 +11,6 @@ export let validateValueRequired = <T>(x: any, item: IMesonFieldItemHasValue<T>)
   }
 };
 
-export let validateByMethods = <T>(x: any, methods: (EMesonValidate | FuncMesonValidator<T>)[], item: IMesonFieldItemHasValue<T>): string => {
-  for (let idx in methods) {
-    let method = methods[idx];
-    if (method === EMesonValidate.Number) {
-      if (!isNumber(x)) {
-        return formatString(lingual.labelShouldBeNumber, { label: item.label });
-      }
-    } else if (method === EMesonValidate.String) {
-      if (!isString(x)) {
-        return formatString(lingual.labelShouldBeString, { label: item.label });
-      }
-    } else if (method === EMesonValidate.Boolean) {
-      if (!isBoolean(x)) {
-        return formatString(lingual.labelShouldBeBoolean, { label: item.label });
-      }
-    } else if (isFunction(x)) {
-      return method(x, item);
-    } else {
-      console.warn("Unknown method", method);
-    }
-  }
-  return null;
-};
-
 export let validateItem = <T>(x: any, item: IMesonFieldItemHasValue<T>, formValue: T): string => {
   if (item.validator != null) {
     let ret = item.validator(x, item, formValue);
@@ -41,8 +18,8 @@ export let validateItem = <T>(x: any, item: IMesonFieldItemHasValue<T>, formValu
       return ret;
     }
   }
-  if (isArray(item.validateMethods)) {
-    let ret = validateByMethods(x, item.validateMethods, item);
+  if (item.validateRules != null) {
+    let ret = ruledValidate(x, item.validateRules);
     if (ret != null) {
       return ret;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -235,6 +235,11 @@
     lodash-es "^4.17.15"
     query-string "^6.13.1"
 
+"@jimengio/ruled-validator@^0.1.1-a1":
+  version "0.1.1-a1"
+  resolved "https://registry.npmjs.org/@jimengio/ruled-validator/-/ruled-validator-0.1.1-a1.tgz#5277e05c23d65710b622ea11a0040f5b23f4d3f2"
+  integrity sha512-9pNccR8wYXiKpEdIolcPJb5l+w0uvaBVFzvgycQa0B4MloJMpgP9QuGDchKCFqiJ1ezAiIq+ICmXw70CPfcYUw==
+
 "@jimengio/safe-property@^0.0.2":
   version "0.0.2"
   resolved "https://registry.npmjs.org/@jimengio/safe-property/-/safe-property-0.0.2.tgz#62d824660a56a6eb29628c1c795b256b9639743b"


### PR DESCRIPTION
以往的 `validateMethods` 过于粗糙, 业务当中没有在使用. 目前使用的是 `validator` 方法. 参考用例改成了 `validateRules` 的规则, 具体使用规则参考 https://github.com/jimengio/ruled-validator/blob/master/src/validate.test.ts .
